### PR TITLE
docs: replace ASCII diagrams with Mermaid for unified rendering

### DIFF
--- a/docs/grafana-integration.md
+++ b/docs/grafana-integration.md
@@ -6,14 +6,27 @@ The goal: an operator with 5+ Linux hosts and zero Loki experience can go from `
 
 ## Architecture
 
-```
-┌──────────┐     ┌─────────┐     ┌──────┐     ┌─────────┐
-│ PAMSignal│ ──> │ journald│ ──> │ Alloy│ ──> │  Loki   │ ──┐
-└──────────┘     └─────────┘     └──────┘     └─────────┘   │
-                                                            v
-                                                       ┌─────────┐
-                                                       │ Grafana │
-                                                       └─────────┘
+```mermaid
+graph LR
+    pamsignal["PAMSignal<br/>(per host)"]
+    journald[("systemd-journald<br/>(per host)")]
+    alloy["Grafana Alloy<br/>(per host)"]
+    loki[("Loki")]
+    grafana["Grafana"]
+    operator["🧑‍💻 Operator"]
+
+    pamsignal -- "sd_journal_send<br/>(ECS fields)" --> journald
+    journald -- "SYSLOG_IDENTIFIER=pamsignal" --> alloy
+    alloy -- "Loki push API<br/>(4 labels)" --> loki
+    loki -- "LogQL queries" --> grafana
+    grafana -- "fleet dashboard<br/>+ alerts" --> operator
+
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style alloy fill:#457b9d,stroke:#1d3557,color:#fff
+    style loki fill:#e9c46a,stroke:#f4a261,color:#000
+    style grafana fill:#e76f51,stroke:#d62828,color:#fff
+    style operator fill:#6c757d,stroke:#495057,color:#fff
 ```
 
 PAMSignal already emits ECS-aligned structured fields via `sd_journal_send()`. Alloy scrapes journald for `SYSLOG_IDENTIFIER=pamsignal`, promotes a small set of low-cardinality fields to Loki labels, and forwards the rest as a JSON-encoded log line. Grafana queries Loki via LogQL.

--- a/docs/notes/systemd-journal.md
+++ b/docs/notes/systemd-journal.md
@@ -15,32 +15,38 @@
 
 To understand how PAMSignal works, we need to understand the layered architecture of a Linux system:
 
-```
-┌─────────────────────────────────────────────────────┐
-│              User Space Applications                │
-│  (SSH clients, login, sudo, web apps, PAMSignal)    │
-└─────────────────────┬───────────────────────────────┘
-                      │ System Calls
-┌─────────────────────▼───────────────────────────────┐
-│            System Libraries & Services              │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────┐  │
-│  │     PAM      │  │   systemd    │  │  glibc    │  │
-│  │ (libpam.so)  │  │(libsystemd)  │  │           │  │
-│  └──────┬───────┘  └──────┬───────┘  └───────────┘  │
-└─────────┼──────────────────┼────────────────────────┘
-          │                  │
-┌─────────▼──────────────────▼──────────────────────────┐
-│                  Linux Kernel                         │
-│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐   │
-│  │   Security   │  │   Process    │  │  Logging   │   │
-│  │  Subsystem   │  │  Management  │  │  (printk)  │   │
-│  └──────────────┘  └──────────────┘  └────────────┘   │
-└───────────────────────────────────────────────────────┘
-          │
-┌─────────▼─────────────────────────────────────────────┐
-│                    Hardware                           │
-│         (CPU, Memory, Disk, Network)                  │
-└───────────────────────────────────────────────────────┘
+```mermaid
+graph TD
+    subgraph userspace ["User Space Applications"]
+        apps["SSH clients · login · sudo · web apps · PAMSignal"]
+    end
+
+    subgraph libs ["System Libraries & Services"]
+        pam["PAM<br/>(libpam.so)"]
+        systemd["systemd<br/>(libsystemd)"]
+        glibc["glibc"]
+    end
+
+    subgraph kernel ["Linux Kernel"]
+        security["Security<br/>Subsystem"]
+        process["Process<br/>Management"]
+        logging["Logging<br/>(printk)"]
+    end
+
+    hardware["Hardware<br/>CPU · Memory · Disk · Network"]
+
+    apps -- "system calls" --> libs
+    libs --> kernel
+    kernel --> hardware
+
+    style apps fill:#6c757d,stroke:#495057,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style systemd fill:#264653,stroke:#1d3557,color:#fff
+    style glibc fill:#577590,stroke:#1d3557,color:#fff
+    style security fill:#4a4e69,stroke:#22223b,color:#fff
+    style process fill:#4a4e69,stroke:#22223b,color:#fff
+    style logging fill:#4a4e69,stroke:#22223b,color:#fff
+    style hardware fill:#22223b,stroke:#000,color:#fff
 ```
 
 **Key Layers:**
@@ -54,32 +60,24 @@ To understand how PAMSignal works, we need to understand the layered architectur
 
 When a user attempts to log in (via SSH, console, or GUI), the following happens:
 
-```
-User Login Attempt
-       │
-       ▼
-┌──────────────┐
-│ Login App    │ (sshd, login, gdm)
-│ (User Space) │
-└──────┬───────┘
-       │ Calls PAM API
-       ▼
-┌──────────────┐
-│     PAM      │ Checks /etc/pam.d/ configuration
-│  (libpam)    │ Executes PAM modules in order
-└──────┬───────┘
-       │ Logs to syslog/journal
-       ▼
-┌──────────────┐
-│   systemd    │ Receives log entry
-│  journald    │ Stores in binary journal
-└──────┬───────┘
-       │ Event notification
-       ▼
-┌──────────────┐
-│  PAMSignal   │ Reads journal via libsystemd
-│ (Subscriber) │ Processes & sends alerts
-└──────────────┘
+```mermaid
+graph TD
+    login["User login attempt"]
+    app["Login App<br/>sshd · login · gdm"]
+    pam["PAM (libpam)<br/>checks /etc/pam.d/<br/>executes modules in order"]
+    journald[("systemd-journald<br/>receives log entry<br/>stores in binary journal")]
+    pamsignal["PAMSignal (subscriber)<br/>reads via libsystemd<br/>processes & sends alerts"]
+
+    login --> app
+    app -- "calls PAM API" --> pam
+    pam -- "logs to syslog/journal" --> journald
+    journald -- "event notification" --> pamsignal
+
+    style login fill:#6c757d,stroke:#495057,color:#fff
+    style app fill:#577590,stroke:#1d3557,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
 ```
 
 ## 3. What is PAM (Pluggable Authentication Module)?
@@ -291,45 +289,24 @@ Feb 17 22:30:15 server sshd[12345]: pam_unix(sshd:session): session opened for u
 
 ### 5.1 High-Level Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    User Login Event                         │
-│  (SSH, console, GUI, sudo, su, etc.)                        │
-└────────────────────────┬────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  PAM Authentication                         │
-│  1. Verify credentials (password, key, 2FA)                 │
-│  2. Check account validity                                  │
-│  3. Setup session                                           │
-│  4. Log authentication event                                │
-└────────────────────────┬────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────────────┐
-│              systemd-journald (Log Collector)               │
-│  - Receives log from PAM                                    │
-│  - Adds metadata (_PID, _UID, _HOSTNAME, etc.)              │
-│  - Writes to binary journal (/var/log/journal/)             │
-│  - Notifies subscribers (PAMSignal)                         │
-└────────────────────────┬────────────────────────────────────┘
-                         │ Event notification
-                         ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  PAMSignal Subscriber                       │
-│  1. Receive event via sd_journal_wait()                     │
-│  2. Extract authentication data                             │
-│  3. Determine login type (SSH, console, sudo, etc.)         │
-│  4. Gather context (IP, hostname, user, timestamp)          │
-│  5. Send notification (Telegram, email, webhook)            │
-└─────────────────────────────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────────────┐
-│                  User Notification                          │
-│  "🔐 SSH login: user@192.168.1.100 → server (22:30:15)"     │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+graph TD
+    login["User Login Event<br/>SSH · console · GUI · sudo · su"]
+    pam["PAM Authentication<br/>1. verify credentials (password / key / 2FA)<br/>2. check account validity<br/>3. setup session<br/>4. log auth event"]
+    journald[("systemd-journald (log collector)<br/>receives from PAM · adds metadata<br/>writes binary journal · notifies subscribers")]
+    pamsignal["PAMSignal subscriber<br/>1. sd_journal_wait()<br/>2. extract auth data<br/>3. determine login type<br/>4. gather context<br/>5. send notification"]
+    notify["User notification<br/>🔐 SSH login: user@192.168.1.100 → server"]
+
+    login --> pam
+    pam --> journald
+    journald -- "event notification" --> pamsignal
+    pamsignal -- "Telegram · Slack · Webhook · Email" --> notify
+
+    style login fill:#6c757d,stroke:#495057,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style notify fill:#e9c46a,stroke:#f4a261,color:#000
 ```
 
 ### 5.2 PAMSignal Internal Workflow
@@ -518,34 +495,40 @@ systemd provides a unified, modern approach to system management that addresses 
 
 **How it works:**
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Log Sources                          │
-├─────────────┬──────────────┬──────────────┬─────────────┤
-│   Kernel    │   Services   │  Applications │   Syslog   │
-│   (kmsg)    │  (stdout)    │  (sd_journal) │  (legacy)  │
-└──────┬──────┴──────┬───────┴──────┬────────┴─────┬──────┘
-       │             │              │              │
-       └─────────────┴──────────────┴──────────────┘
-                         │
-                         ▼
-              ┌──────────────────────┐
-              │  systemd-journald    │
-              │  (Central Collector) │
-              └──────────┬───────────┘
-                         │
-                         ▼
-              ┌──────────────────────┐
-              │   Binary Journal     │
-              │   /var/log/journal/  │
-              │   (Indexed, Sealed)  │
-              └──────────┬───────────┘
-                         │
-         ┌───────────────┼───────────────┐
-         │               │               │
-         ▼               ▼               ▼
-    journalctl      libsystemd      rsyslog
-    (Query CLI)     (Event API)     (Forward)
+```mermaid
+graph TD
+    kernel["Kernel<br/>(kmsg)"]
+    services["Services<br/>(stdout)"]
+    apps["Applications<br/>(sd_journal)"]
+    syslog["Syslog<br/>(legacy)"]
+
+    journald[("systemd-journald<br/>(central collector)")]
+    binary[("Binary journal<br/>/var/log/journal/<br/>indexed · sealed")]
+
+    journalctl["journalctl<br/>(query CLI)"]
+    libsystemd["libsystemd<br/>(event API)"]
+    rsyslog["rsyslog<br/>(forward)"]
+
+    kernel --> journald
+    services --> journald
+    apps --> journald
+    syslog --> journald
+
+    journald --> binary
+
+    binary --> journalctl
+    binary --> libsystemd
+    binary --> rsyslog
+
+    style kernel fill:#4a4e69,stroke:#22223b,color:#fff
+    style services fill:#577590,stroke:#1d3557,color:#fff
+    style apps fill:#577590,stroke:#1d3557,color:#fff
+    style syslog fill:#6c757d,stroke:#495057,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style binary fill:#1d3557,stroke:#22223b,color:#fff
+    style journalctl fill:#e9c46a,stroke:#f4a261,color:#000
+    style libsystemd fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style rsyslog fill:#6c757d,stroke:#495057,color:#fff
 ```
 
 **Key Features:**

--- a/examples/fail2ban/README.md
+++ b/examples/fail2ban/README.md
@@ -11,17 +11,21 @@ If you've never used Fail2ban before — that's fine. The guide explains every c
 
 ## What you'll have at the end
 
-```
-Attacker tries SSH login 5 times in 5 minutes
-              │
-              ▼
-PAMSignal writes BRUTE_FORCE_DETECTED to the systemd journal
-              │
-              ▼
-Fail2ban sees the journal entry and runs an iptables/firewalld rule
-              │
-              ▼
-Attacker's IP is dropped at the kernel — they can't reach SSH (or any port) for 24 hours
+```mermaid
+graph TD
+    attacker["Attacker tries SSH login<br/>5 times in 5 minutes"]
+    pamsignal["PAMSignal<br/>writes BRUTE_FORCE_DETECTED<br/>to the systemd journal"]
+    fail2ban["Fail2ban<br/>sees the journal entry<br/>runs iptables / firewalld rule"]
+    kernel["Attacker's IP dropped at the kernel<br/>can't reach SSH (or any port) for 24h"]
+
+    attacker --> pamsignal
+    pamsignal --> fail2ban
+    fail2ban --> kernel
+
+    style attacker fill:#6c757d,stroke:#495057,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style fail2ban fill:#e76f51,stroke:#d62828,color:#fff
+    style kernel fill:#4a4e69,stroke:#22223b,color:#fff
 ```
 
 No log-parsing regex to maintain, no thresholds to keep in sync between two tools. PAMSignal already did the math; Fail2ban just acts on its signal.
@@ -370,32 +374,25 @@ A reload preserves existing bans; a full `restart` clears them.
 
 ## How it works under the hood
 
-```
-┌──────────────────────────┐
-│  sshd, sudo, su, login   │  PAM-stack daemons emit auth events
-└────────────┬─────────────┘
-             │ journald
-             ▼
-┌──────────────────────────┐
-│  systemd journal         │  Structured, queryable, persistent
-└────────────┬─────────────┘
-             │ sd_journal_*  (reads)              ▲
-             ▼                                     │ sd_journal_send (writes)
-┌──────────────────────────┐                       │
-│  PAMSignal daemon        │  Parses, counts,      │
-│                          │  thresholds, alerts ──┘
-└──────────────────────────┘  Writes BRUTE_FORCE_DETECTED back to journal with SYSLOG_IDENTIFIER=pamsignal
-             │
-             ▼
-┌──────────────────────────┐
-│  Fail2ban (this guide)   │  Tails journal with journalmatch=SYSLOG_IDENTIFIER=pamsignal
-│                          │  On regex match, runs `iptables` / `firewall-cmd` / `ufw`
-└────────────┬─────────────┘
-             │
-             ▼
-┌──────────────────────────┐
-│  Kernel netfilter        │  Attacker's IP is dropped before it reaches sshd
-└──────────────────────────┘
+```mermaid
+graph TD
+    sshd["sshd · sudo · su · login<br/>PAM-stack daemons emit auth events"]
+    journal[("systemd journal<br/>structured · queryable · persistent")]
+    pamsignal["PAMSignal daemon<br/>parses · counts · thresholds · alerts"]
+    fail2ban["Fail2ban (this guide)<br/>journalmatch=SYSLOG_IDENTIFIER=pamsignal<br/>runs iptables / firewall-cmd / ufw"]
+    netfilter["Kernel netfilter<br/>attacker's IP dropped before reaching sshd"]
+
+    sshd -- "PAM auth events" --> journal
+    journal -- "sd_journal_* (reads)" --> pamsignal
+    pamsignal -- "sd_journal_send<br/>BRUTE_FORCE_DETECTED" --> journal
+    journal -- "tails for regex match" --> fail2ban
+    fail2ban -- "drop rule" --> netfilter
+
+    style sshd fill:#6c757d,stroke:#495057,color:#fff
+    style journal fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style fail2ban fill:#e76f51,stroke:#d62828,color:#fff
+    style netfilter fill:#4a4e69,stroke:#22223b,color:#fff
 ```
 
 The two daemons are completely decoupled: PAMSignal doesn't know Fail2ban exists, and Fail2ban doesn't know PAMSignal exists. They communicate through the structured journal, which is durable, multi-reader-safe, and the canonical event log on systemd Linux. If you uninstall Fail2ban tomorrow, PAMSignal keeps working unchanged.

--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -154,14 +154,27 @@ step broke.
 
 ## Architecture
 
-```
-┌──────────┐    ┌──────────┐    ┌───────┐    ┌──────┐    ┌─────────┐
-│PAMSignal │──▶│ journald │──▶│ Alloy │──▶│ Loki │──▶│ Grafana │
-│ (per host)│    │ (per host) │  │(per host)│ │      │    │         │
-└──────────┘    └──────────┘    └───────┘    └──────┘    └─────────┘
-                                                                ▲
-                                                                │
-                                                            operator
+```mermaid
+graph LR
+    pamsignal["PAMSignal<br/>(per host)"]
+    journald[("systemd-journald<br/>(per host)")]
+    alloy["Grafana Alloy<br/>(per host)"]
+    loki[("Loki")]
+    grafana["Grafana"]
+    operator["🧑‍💻 Operator"]
+
+    pamsignal -- "sd_journal_send<br/>(ECS fields)" --> journald
+    journald -- "SYSLOG_IDENTIFIER=pamsignal" --> alloy
+    alloy -- "Loki push API<br/>(4 labels)" --> loki
+    loki -- "LogQL queries" --> grafana
+    grafana -- "fleet dashboard<br/>+ alerts" --> operator
+
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style alloy fill:#457b9d,stroke:#1d3557,color:#fff
+    style loki fill:#e9c46a,stroke:#f4a261,color:#000
+    style grafana fill:#e76f51,stroke:#d62828,color:#fff
+    style operator fill:#6c757d,stroke:#495057,color:#fff
 ```
 
 **Why this shape:**


### PR DESCRIPTION
Follow-up to #25. Converts 8 ASCII box-drawing diagrams to Mermaid so every architecture diagram in the repo renders consistently on GitHub and shares the same visual palette as the main README's existing Mermaid graph.

## What changed

| File | Diagrams | Layout |
|---|---|---|
| `docs/grafana-integration.md` | 1 | Fleet architecture (`graph LR`) |
| `examples/grafana/README.md` | 1 | Fleet architecture (`graph LR`) |
| `examples/fail2ban/README.md` | 2 | End-state flow + detailed integration (`graph TD`) |
| `docs/notes/systemd-journal.md` | 4 | Linux layers, auth flow, PAMSignal high-level, journald topology (mostly `graph TD`, `subgraph` where layering matters) |

## Unified palette across every diagram

| Colour | Hex | Used for |
|---|---|---|
| Green | `#2d6a4f` | PAMSignal |
| Dark blue | `#264653` | systemd-journald (cylinder shape `[(...)]`) |
| Blue | `#577590` / `#457b9d` | PAM / system libs / Alloy |
| Yellow | `#e9c46a` | Loki / journalctl / notifications |
| Orange-red | `#e76f51` | Grafana / Fail2ban |
| Purple | `#4a4e69` | Kernel / netfilter |
| Black | `#22223b` | Hardware |
| Grey | `#6c757d` | External daemons (sshd, login, …) |

Matches the existing Mermaid graph in the main README so the project's visual identity is consistent.

## Intentionally kept as ASCII

- The `examples/grafana/` directory-tree listing in `docs/grafana-integration.md` (line ~168)
- The `/etc/pam.d/` directory tree in `docs/notes/systemd-journal.md` (line ~101)
- Two pseudocode-in-box blocks comparing PAMSignal's old polling loop vs new event-driven flow (`systemd-journal.md` lines ~166 and ~222) — the C-like code inside is the point, not the flow

## Test plan

- [ ] Render each touched file's preview on GitHub and confirm all eight Mermaid blocks render
- [ ] Confirm the diagrams are readable on a phone (no horizontal scrolling) — `graph TD` orientation chosen on diagrams with >5 nodes for exactly this reason
- [ ] Spot-check the dark-mode rendering on GitHub — Mermaid uses our `style fill:` colours regardless of theme so the palette stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)