### PR TITLE
docs: record grafana.com + launch as deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 
 Design rationale lives in `docs/grafana-integration.md` (schema, label cardinality plan, dashboard story, LogQL query patterns, deliverable layout, success criteria). No PAMSignal daemon changes — the integration consumes the ECS structured fields PAMSignal already emits via `sd_journal_send()`.
 
-- [ ] Submit `pamsignal-v1.json` to [grafana.com/grafana/dashboards](https://grafana.com/grafana/dashboards/) (manual, post-merge)
-- [ ] Launch posts: r/selfhosted, r/sysadmin, r/grafana, Show HN
+The repo ships the canonical dashboard JSON (`examples/grafana/dashboards/pamsignal-v1.grafana-com.json`), which powers Grafana's UI Import directly. Submitting to grafana.com and the social-launch push are deliberately deferred — the dashboard is daemon-coupled, so the primary distribution funnel is "install PAMSignal → dashboard ships in `examples/grafana/`", not marketplace discovery. Both remain a 5-minute step if an audience materializes.
+
+Also: all ASCII architecture diagrams across the docs (Grafana integration, Fail2ban guide, systemd-journal notes) converted to Mermaid with a unified colour palette matching the main README.
 
 ## 0.6.1 — 2026-05-27
 


### PR DESCRIPTION
Small CHANGELOG update following the decision to skip issue #25 phases 9 (grafana.com submission) and 10 (social launch).

## Why defer rather than do

The dashboard is **daemon-coupled** — useless without PAMSignal installed. So the real distribution funnel is "install PAMSignal → dashboard ships in `examples/grafana/`", not grafana.com marketplace discovery (whose browsers want standalone dashboards). The `pamsignal-v1.grafana-com.json` already in the repo powers Grafana's drag-and-drop UI Import, so nothing is lost by waiting. Both are a 5-minute step if an audience materializes later.

## Changes

- Replaces the two `- [ ]` checklist items under Unreleased with a prose note explaining the deferral + reasoning
- Adds a line recording the ASCII→Mermaid diagram conversion (PRs #27)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)