### PR TITLE
docs: add Vietnamese translations + bilingual docs rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ journalctl -t pamsignal -f
 - `src/` — 6 C modules: main, config, init, journal_watch, notify, utils
 - `include/` — corresponding headers
 - `docs/` — architecture, configuration, alerts, development, deployment guides
+- `docs/vi/` — Vietnamese mirror of all user-facing docs (see Documentation rule)
 - `meson.build` — build configuration
 - `pamsignal.service` — systemd unit file
 - `pamsignal.conf.example` — config template
@@ -50,6 +51,24 @@ journalctl -t pamsignal -f
 - **Types:** `_t` suffix for structs and enums (e.g., `ps_pam_event_t`, `ps_event_type_t`)
 - **Error handling:** Return code enums (`PS_OK`, `PS_ERR_*`), early returns
 - **Logging:** `sd_journal_print()` / `sd_journal_send()` — not printf/syslog
+
+## Documentation (Bilingual EN/VI)
+
+Every user-facing Markdown doc exists in **both English and Vietnamese**. English is the source of truth; Vietnamese is a mirror under `docs/vi/`.
+
+**Rule: whenever you add or edit any English doc, update its Vietnamese counterpart in the same change.** The two must never drift. When you add a brand-new English doc, create the matching `docs/vi/` file and wire up the language switcher both ways.
+
+- **Layout** — the Vietnamese tree mirrors the English one under `docs/vi/`:
+  - `README.md` → `docs/vi/README.md`, `SECURITY.md` → `docs/vi/SECURITY.md`, `CONTRIBUTING.md` → `docs/vi/CONTRIBUTING.md`
+  - `docs/<name>.md` → `docs/vi/<name>.md`
+  - `docs/notes/<name>.md` → `docs/vi/notes/<name>.md`
+  - `examples/<name>/README.md` → `docs/vi/examples/<name>.md`
+- **Language switcher** — first line after the H1 of every doc (both EN and VI), as a blockquote:
+  - EN file: `> 🌐 **English** · [Tiếng Việt](<relative-path-to-vi>)`
+  - VI file: `> 🌐 [English](<relative-path-to-en>) · **Tiếng Việt**`
+- **Translation style** — natural Vietnamese for a sysadmin/developer audience, not stiff machine translation. Keep ALL technical terms, identifiers, config keys, CLI flags, file paths, code blocks, shell commands, URLs, and Mermaid/ASCII diagrams in English / verbatim. Translate only prose, heading text, and table prose. Structure stays 1:1 (same heading levels, section count, anchors).
+- **Links inside VI docs** — links to other translated docs point to their VI counterparts; links to non-translated files (source, `CHANGELOG.md`, `LICENSE`, `assets/`, `.claude/`) point to the real file with the relative depth recomputed for the deeper `docs/vi/` location. Cross-document anchor links must target the **translated heading's slug** (a Vietnamese heading produces a Vietnamese, diacritics-included slug).
+- **Not mirrored** — `CHANGELOG.md`, `LICENSE`, source code. `docs/launch-posts/` is already bilingual by design.
 
 ## Security Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to PAMSignal
 
+> 🌐 **English** · [Tiếng Việt](docs/vi/CONTRIBUTING.md)
+
 Thanks for your interest. PAMSignal is a small C daemon with a tight focus on detecting PAM auth events and dispatching alerts; the deliberately narrow scope is part of the project's threat model. Please read [`docs/threat-model.md`](./docs/threat-model.md) before proposing a feature — it's the reference for whether a change strengthens an in-scope mitigation or pulls work into the daemon from an out-of-scope area.
 
 This document covers how to make code, doc, and packaging contributions. For:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PAMSignal 🚨
 
+> 🌐 **English** · [Tiếng Việt](docs/vi/README.md)
+
 ![License](https://img.shields.io/github/license/anhtuank7c/pamsignal)
 ![Language](https://img.shields.io/badge/Language-C-orange)
 ![Platform](https://img.shields.io/badge/Platform-Linux-lightgrey)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+> 🌐 **English** · [Tiếng Việt](docs/vi/SECURITY.md)
+
 PAMSignal is a security-monitoring daemon. A vulnerability in the daemon itself — bypass of the brute-force tracker, alert spoofing, log injection, privilege escalation, memory corruption — is treated as a high-priority defect. This document describes how to report one privately and what to expect once you do.
 
 ## Reporting a Vulnerability

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,5 +1,7 @@
 # Alerts
 
+> 🌐 **English** · [Tiếng Việt](vi/alerts.md)
+
 PAMSignal sends best-effort alerts to messaging platforms when login events or brute-force patterns are detected. Alerts are sent via `fork()+exec(curl)` — a short-lived child process that cannot affect the core monitoring.
 
 If an alert fails (network down, API error, timeout), pamsignal logs a warning and continues. The event is always persisted in the journal first.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+> 🌐 **English** · [Tiếng Việt](vi/architecture.md)
+
 PAMSignal is designed around one core principle: **do one thing well with minimal moving parts.**
 
 It subscribes to the systemd journal, filters for PAM-related messages from sshd, sudo, su, and login, parses each message to extract structured data (username, source IP, port, service, auth method), and writes structured events back to the journal with custom fields. It tracks failed login attempts per IP and detects brute-force patterns. Optionally, it sends best-effort alerts to messaging platforms without risking the core monitoring.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
 # Configuration
 
+> 🌐 **English** · [Tiếng Việt](vi/configuration.md)
+
 `/etc/pamsignal/pamsignal.conf` — INI-style, zero dependencies. All values are optional; sane defaults apply if the file is missing or a key is absent.
 
 Since this file may contain alert credentials, it should have restricted permissions:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment
 
+> 🌐 **English** · [Tiếng Việt](vi/deployment.md)
+
 ## Install
 
 The recommended path is the published `.deb` or `.rpm` from the project repo (the same one-liners in the [README quick start](../README.md#1-install)). The packages create the `pamsignal` system user, set the config-file permissions to `root:pamsignal 0640`, and arm the systemd unit for you — when you install via `apt` or `dnf` you can skip straight to [Configure](#configure).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,7 @@
 # Development Guide
 
+> 🌐 **English** · [Tiếng Việt](vi/development.md)
+
 ## Prerequisites
 
 ```bash

--- a/docs/distros.md
+++ b/docs/distros.md
@@ -1,5 +1,7 @@
 # Supported Linux Distributions
 
+> 🌐 **English** · [Tiếng Việt](vi/distros.md)
+
 PAMSignal is designed for modern systemd-native Linux. Older releases either don't have the libc functions the daemon calls (`memfd_create`, used for credential isolation in the alert dispatch path), don't have the systemd unit directives the project's hardening relies on (`ProcSubset=pid`, `ProtectProc=invisible`, `ProtectClock=`, `ProtectHostname=`, `RestrictNamespaces=`, the `@system-service` syscall set), or don't have a recent enough debhelper to build the package. This document is the canonical reference for "will pamsignal run on my host?" and is referenced from [`SECURITY.md`](../SECURITY.md) and the [README](../README.md) docs index.
 
 The support tiers below have different meanings and different commitments:

--- a/docs/grafana-integration.md
+++ b/docs/grafana-integration.md
@@ -1,5 +1,7 @@
 # Grafana Integration — Design
 
+> 🌐 **English** · [Tiếng Việt](vi/grafana-integration.md)
+
 This document is the locked design for the PAMSignal Grafana integration, tracked in [issue #25](https://github.com/anhtuank7c/pamsignal/issues/25). Implementation artifacts live under `examples/grafana/`.
 
 The goal: an operator with 5+ Linux hosts and zero Loki experience can go from `apt install pamsignal` to a working fleet-wide auth dashboard in under 30 minutes.

--- a/docs/notes/meson-build-system.md
+++ b/docs/notes/meson-build-system.md
@@ -1,5 +1,7 @@
 # Meson & Ninja: Build Tools
 
+> 🌐 **English** · [Tiếng Việt](../vi/notes/meson-build-system.md)
+
 - **Status**: Completed
 - **Start Date**: 20/02/2026
 - **Completion Date**: 20/02/2026

--- a/docs/notes/project-initialization.md
+++ b/docs/notes/project-initialization.md
@@ -1,5 +1,7 @@
 # Step 1 - Initialize (Project Initialization)
 
+> 🌐 **English** · [Tiếng Việt](../vi/notes/project-initialization.md)
+
 - **Status**: Completed
 - **Start Date**: 26/12/2025
 - **Completion Date**: 26/12/2025

--- a/docs/notes/systemd-journal.md
+++ b/docs/notes/systemd-journal.md
@@ -1,5 +1,7 @@
 # Journal Subscriber
 
+> 🌐 **English** · [Tiếng Việt](../vi/notes/systemd-journal.md)
+
 - **Status**: Completed
 - **Start Date**: 27/12/2025
 - **Completion Date**: 17/02/2026

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,5 +1,7 @@
 # Threat Model
 
+> 🌐 **English** · [Tiếng Việt](vi/threat-model.md)
+
 This document describes what PAMSignal defends against, what it deliberately does not, and the design choices that produce that posture. It is the reference for evaluating future contributions: a change that strengthens an in-scope mitigation is welcome; a change that pulls work into the daemon from an out-of-scope area is not, even if it would be technically possible.
 
 For private vulnerability reporting, see [`SECURITY.md`](../SECURITY.md). The two documents are complementary — `SECURITY.md` is operator-facing (how to report, what versions are supported); this document is contributor-facing (what the daemon's responsibilities are and what they aren't).

--- a/docs/vi/CONTRIBUTING.md
+++ b/docs/vi/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Đóng Góp cho PAMSignal
+
+> 🌐 [English](../../CONTRIBUTING.md) · **Tiếng Việt**
+
+Cảm ơn bạn đã quan tâm. PAMSignal là một C daemon nhỏ với trọng tâm chặt chẽ vào việc phát hiện các sự kiện PAM auth và gửi cảnh báo; phạm vi cố ý hẹp là một phần trong threat model của dự án. Vui lòng đọc [`docs/threat-model.md`](../../docs/threat-model.md) trước khi đề xuất tính năng — đây là tài liệu tham chiếu để xác định liệu một thay đổi có tăng cường một biện pháp giảm thiểu trong phạm vi hay đưa công việc từ ngoài phạm vi vào daemon.
+
+Tài liệu này bao gồm cách thực hiện đóng góp về code, tài liệu và packaging. Đối với:
+
+- **Báo cáo lỗ hổng bảo mật** → [`SECURITY.md`](SECURITY.md). Không tạo GitHub issue công khai cho các báo cáo bảo mật.
+- **Báo cáo lỗi không liên quan đến bảo mật** → [mở một bug-report issue](https://github.com/anhtuank7c/pamsignal/issues/new?template=bug_report.yml).
+- **Đề xuất tính năng** → [mở một feature-request issue](https://github.com/anhtuank7c/pamsignal/issues/new?template=feature_request.yml) **trước**, trước khi viết code, để chúng ta có thể thảo luận về phạm vi so với threat model.
+- **Đặt câu hỏi / thảo luận về cách dùng** → kiểm tra [`README.md`](../../README.md), [`docs/`](../../docs/), và các GitHub Issues hiện có. Nếu câu hỏi của bạn chưa được giải đáp, hãy mở một issue kiểu feature-request và gắn nhãn `question`.
+
+## Bắt Đầu Nhanh
+
+```bash
+git clone https://github.com/anhtuank7c/pamsignal.git
+cd pamsignal
+
+# Install build deps (Debian/Ubuntu)
+sudo apt-get install -y --no-install-recommends \
+  meson ninja-build pkg-config gcc \
+  libsystemd-dev libcmocka-dev clang-format clang-tidy
+
+# Build + test
+meson setup build
+meson compile -C build
+meson test -C build
+```
+
+Để được hướng dẫn build/debug sâu hơn — fuzzing, chạy ASAN local, các pattern introspection với journalctl, đóng gói thành `.deb` / `.rpm` — xem [`docs/development.md`](../../docs/development.md). Để biết chi tiết về systemd unit + sandbox, xem [`docs/deployment.md`](../../docs/deployment.md).
+
+## Quy Trình Branch + Commit
+
+1. Fork và tạo branch từ `main`. Một branch cho mỗi thay đổi logic.
+2. Thực hiện thay đổi của bạn. Giữ các commit nhỏ và tập trung — người review phải có thể hiểu từng commit một cách độc lập.
+3. Chạy [danh sách kiểm tra pre-commit](#danh-sách-kiểm-tra-pre-commit) bên dưới. **Mọi mục đều bắt buộc để PR được merge.**
+4. Push branch của bạn và mở PR đối với `main`. Điền vào PR template.
+5. CI chạy ASAN+UBSAN sanitizers trên mọi push đến PR; cả hai phải pass.
+
+### Commit message
+
+Dự án sử dụng [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <imperative subject under 72 chars>
+
+<optional body explaining *why*, not *what*>
+```
+
+Các type được sử dụng ở đây:
+
+| Type | Khi nào |
+|---|---|
+| `feat:` | Tính năng hoặc hành vi mới |
+| `fix:` | Sửa lỗi |
+| `security:` | Security hardening hoặc sửa lỗ hổng |
+| `refactor:` | Tái cấu trúc không thay đổi hành vi |
+| `refactor!:` | Tái cấu trúc với breaking behavior change |
+| `docs:` | Chỉ tài liệu |
+| `chore:` | Build, CI, packaging, tooling, dependencies |
+| `test:` | Thêm hoặc cập nhật tests |
+| `perf:` | Cải thiện hiệu năng |
+
+Quy tắc:
+
+- Subject dùng **imperative mood** ("add", "fix", "update" — không phải "added", "fixes", "updated").
+- Không có dấu chấm ở cuối subject.
+- Body giải thích *tại sao* cần thay đổi; diff đã cho thấy *cái gì* thay đổi.
+- Tham chiếu issue bằng `#NNN` trong body, không phải subject.
+- Sign-off (`Signed-off-by:`) là tùy chọn nhưng được khuyến khích cho các thay đổi đáng kể.
+
+Ví dụ:
+
+```
+fix: stop dropping brute-force counter on SIGHUP reload
+
+Reloading the config previously zeroed the in-memory fail_table,
+which let an attacker SIGHUP-spam the daemon to reset their per-IP
+counter just before crossing the threshold. Preserve the table
+across reloads — config changes shouldn't invalidate observed
+attack state.
+
+Refs #42
+```
+
+## Tiêu Chuẩn Coding
+
+Mã nguồn C tuân theo các quy ước được mã hóa trong `.clang-format` và `.clang-tidy` tại thư mục gốc của repo. Bước kiểm tra pre-commit (bên dưới) chạy cả hai. Cụ thể:
+
+- **Ngôn ngữ**: `gnu17` (đặt trong `meson.build`).
+- **Thụt đầu dòng**: 4 khoảng trắng, không dùng tab.
+- **Functions**: `snake_case` với tiền tố `ps_` (ví dụ `ps_journal_watch_init`).
+- **Globals**: tiền tố `g_` (ví dụ `g_config`).
+- **Macros / `#define`**: `UPPER_SNAKE_CASE` với tiền tố `PS_`.
+- **Types** (struct và enum): hậu tố `_t` (ví dụ `ps_pam_event_t`, `ps_event_type_t`).
+- **Enum constants**: `UPPER_SNAKE_CASE` với tiền tố `PS_` (clang-tidy bắt buộc điều này — thêm enum không có tiền tố sẽ fail lint).
+- **Xử lý lỗi**: return code enum (`PS_OK`, `PS_ERR_*`), early return thay vì các nhánh thành công lồng nhau sâu.
+- **Logging**: `sd_journal_print()` / `sd_journal_send()`. **Không được** gọi `printf`, `syslog`, hoặc ghi vào stdout/stderr từ các code path production.
+
+Chính sách comment:
+
+- Mặc định **không viết comment**. Các định danh được đặt tên tốt và các function nhỏ nên làm cho *cái gì* rõ ràng.
+- Thêm comment khi *tại sao* không rõ ràng: một ràng buộc ẩn, một bất biến tinh tế, một workaround cho một lỗi cụ thể, hành vi sẽ khiến người đọc ngạc nhiên. Bao gồm đủ context để comment còn giá trị theo thời gian — tham chiếu CVE liên quan, phần man-page kernel, hoặc định dạng thông điệp PAM nếu có thể.
+
+## Yêu Cầu Test
+
+**Mọi function mới hoặc hành vi đã thay đổi đều phải có test tương ứng trong `tests/`.** Thêm một parser pattern? Thêm tests cho pattern mới, các pattern hiện có mà nó không nên match, và hành vi truncation/edge-case. Thêm một config key? Thêm tests cho các giá trị hợp lệ, giá trị ngoài phạm vi, và fallback khi thiếu key. Thay đổi brute-force tracker? Thêm tests cho tuple mới của `(event-shape, expected counter state)`.
+
+Các test suite được xây dựng bằng CMocka và nằm cạnh các module nguồn mà chúng bao phủ:
+
+| Suite | Bao phủ |
+|---|---|
+| `tests/test_utils.c` | parser, helpers (`sanitize_string`, `is_valid_ip`, ECS helpers) |
+| `tests/test_config.c` | config-file parsing, validation, permission checks |
+| `tests/test_notify.c` | notify dispatch path (smoke tests cho các no-channel path và cooldown) |
+| `tests/test_journal_watch.c` | brute-force tracker (#includes file source trực tiếp để drive file-static state) |
+
+Nếu một thay đổi ảnh hưởng đến hành vi parser, hãy mở rộng `tests/fuzz/parse_message_corpus/` với một input đại diện.
+
+## Danh Sách Kiểm Tra Pre-Commit
+
+Chạy các lệnh này theo thứ tự trước khi mở PR. CI workflow chạy ASAN+UBSAN, nhưng mọi thứ khác là kiểm tra local chạy nhanh hơn trên máy của bạn so với phát hiện qua CI thất bại:
+
+```bash
+# 1. Format
+clang-format -i src/*.c include/*.h tests/*.c
+
+# 2. Lint (must show zero warnings)
+clang-tidy -p build src/*.c tests/*.c
+
+# 3. Build (must show zero warnings)
+meson compile -C build
+
+# 4. Test (all suites must pass)
+meson test -C build
+
+# 5. Optional but recommended: sanitizer build locally
+meson setup build-asan -Db_sanitize=address,undefined -Db_lundef=false --buildtype=debugoptimized
+meson compile -C build-asan
+meson test -C build-asan
+```
+
+Sau đó cập nhật [`CHANGELOG.md`](../../CHANGELOG.md) trong mục `## Unreleased`. Dùng `[x]` cho các mục đã hoàn thành trong branch của bạn và `[ ]` cho các follow-up bạn đang để lại cho sau. Nhóm các mục theo subsection phù hợp (`Features`, `Fixes`, `Security`, `Packaging`, `Documentation`, `CI`).
+
+## Code Review
+
+Một maintainer sẽ review PR của bạn. Dự kiến nhận phản hồi trong vài ngày đối với các thay đổi không nhỏ. Chúng tôi cố gắng giữ các review tập trung vào:
+
+1. **Alignment với threat model** — thay đổi có tăng cường một biện pháp phòng thủ trong phạm vi hay mở rộng daemon vào một non-goal? Xem [`docs/threat-model.md`](../../docs/threat-model.md).
+2. **Độ đầy đủ của test** — test suite có mã hóa thay đổi để một regression trong tương lai sẽ fail CI không?
+3. **Ổn định API** — thay đổi này có đưa vào một config key, journal field, hoặc webhook payload field mà chúng ta sẽ cần hỗ trợ qua các phiên bản không? Các surface công khai được version hóa qua SemVer; các deprecation cần một overlap period (việc retire `PAMSIGNAL_*` trong v0.3.0 là tiền lệ).
+4. **Coding style** — được bao phủ bởi clang-format / clang-tidy; chúng tôi sẽ không tranh cãi về style nếu lần chạy pre-commit của bạn sạch.
+
+Reviewer có thể yêu cầu thay đổi; vui lòng phản hồi trên PR thay vì force-push mà không giải thích. Force-push trong khi review là ổn khi giải quyết rõ ràng một comment, nhưng hãy để lại một ghi chú ngắn trên PR thread nói về những gì đã thay đổi.
+
+## Thay Đổi Distribution và Packaging
+
+Packaging đụng đến `meson.build`, `pamsignal.service.in`, `debian/`, và `pamsignal.spec`. Nếu thay đổi của bạn ảnh hưởng đến bất kỳ file nào trong số này:
+
+- Điểm số `systemd-analyze security` của systemd unit **được gated ở CI ở mức 20** trong `.github/workflows/release-packages.yml` (xem job `test-deb`). Không được loại bỏ một directive hardening mà không có lý do threat-model rõ ràng.
+- Cả `debian/` và `pamsignal.spec` đều cần cập nhật song song nếu thay đổi ảnh hưởng đến những gì được cài đặt; job CI `Verify version consistency` phát hiện sự chênh lệch phiên bản giữa `meson.build`, `debian/changelog`, và `pamsignal.spec`.
+- Block `%changelog` của `pamsignal.spec` được phân tích bởi `rpm` cũ hơn trên EL9; **không** đặt các macro `%xxx` hoặc `%{...}` trong văn bản changelog hay nó sẽ fail build. Viết dưới dạng văn xuôi ("the install section drops..." thay vì "%install drops...").
+
+## Quy Tắc Ứng Xử
+
+Những người đóng góp được kỳ vọng hành xử mang tính xây dựng và tôn trọng lẫn nhau. Người bảo trì có quyền xóa đóng góp hoặc chặn các tài khoản liên tục không làm được điều đó. Nếu bạn trải nghiệm hoặc quan sát hành vi mâu thuẫn với kỳ vọng này, vui lòng gửi email cho người bảo trì tại địa chỉ được liệt kê trong [`SECURITY.md`](SECURITY.md).

--- a/docs/vi/README.md
+++ b/docs/vi/README.md
@@ -1,0 +1,213 @@
+# PAMSignal 🚨
+
+> 🌐 [English](../../README.md) · **Tiếng Việt**
+
+![License](https://img.shields.io/github/license/anhtuank7c/pamsignal)
+![Language](https://img.shields.io/badge/Language-C-orange)
+![Platform](https://img.shields.io/badge/Platform-Linux-lightgrey)
+
+PAMSignal là một login monitor nhẹ, zero-dependency cho Linux server. Nó theo dõi systemd journal để bắt các sự kiện PAM authentication và gửi cảnh báo real-time tới các nền tảng nhắn tin bạn yêu thích.
+
+Nếu bạn quản lý vài server và muốn biết ngay lập tức khi có ai đó đăng nhập hoặc thử brute-force máy của bạn — mà không phải triển khai Wazuh, EDR, hay đọc 200 trang tài liệu — thì đây là thứ dành cho bạn.
+
+## 🙏 Lời cảm ơn
+
+Dự án này sẽ trông rất khác — hoặc không tồn tại — nếu thiếu hai người bạn:
+
+<table>
+<tr>
+<td width="100" align="center" valign="top">
+<a href="https://github.com/hongquan"><img src="https://github.com/hongquan.png" width="72" alt="@hongquan" /></a><br/>
+<sub><b><a href="https://github.com/hongquan">Nguyen Hong&nbsp;Quan</a></b></sub><br/>
+<sub>@hongquan</sub>
+</td>
+<td valign="top">
+
+Đã đưa ra những góp ý thẳng thắn, không nể nang về các chuẩn Linux và kỳ vọng của operator — những điều đã định hình lại roadmap và kiến trúc của PAMSignal. Quyết định thiết kế lớn nhất trong codebase này — subscribe <code>systemd-journald</code> để lấy sự kiện PAM thay vì tail <code>/var/log/auth.log</code> — đến trực tiếp từ sự phản biện của anh. Việc anh nhấn mạnh tuân thủ Linux <a href="https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html">FHS</a> cũng xuyên suốt mọi lựa chọn đường dẫn file trong dự án: binary nằm dưới <code>/usr/bin</code>, config dưới <code>/etc/pamsignal/</code>, runtime state dưới <code>/run/pamsignal/</code>, systemd vendor unit dưới <code>/usr/lib/systemd/system/</code>, và apt repository keyring tại <code>/etc/apt/keyrings/pamsignal.gpg</code> (<a href="https://github.com/anhtuank7c/pamsignal/issues/14">#14</a>). Kết quả là một daemon hòa hợp với hệ sinh thái Linux hiện đại thay vì phải lách qua nó. 🙇
+
+</td>
+</tr>
+<tr>
+<td width="100" align="center" valign="top">
+<a href="https://github.com/lehiep1994"><img src="https://github.com/lehiep1994.png" width="72" alt="@lehiep1994" /></a><br/>
+<sub><b><a href="https://github.com/lehiep1994">Samuel&nbsp;Le</a></b></sub><br/>
+<sub>@lehiep1994</sub>
+</td>
+<td valign="top">
+
+Đã giữ cho mình tiếp tục đọc và tiếp tục xây dựng. Anh gửi cho mình những cuốn sách về Linux internals đúng vào lúc mình cần nhất, và sự động viên bền bỉ để *không* bỏ dở dự án — qua mọi giai đoạn "liệu cái này có đáng ship không?" — là một phần thật sự khiến PAMSignal đi được tới một bản release. 🙇
+
+</td>
+</tr>
+</table>
+
+## ✨ Tại sao chọn PAMSignal?
+
+- **Cảnh báo real-time**: Tích hợp sẵn cho Telegram, Slack, Teams, WhatsApp, Discord, và Custom Webhook.
+- **Bảo vệ chống brute-force**: Tự động đếm số lần thất bại và tích hợp mượt mà với [Fail2ban](examples/fail2ban.md) để chặn kẻ tấn công.
+- **Cực kỳ nhẹ**: Một C binary duy nhất với một file config duy nhất. Dependency duy nhất là `libsystemd`.
+- **Chịu lỗi tốt**: Việc gửi cảnh báo được cô lập qua `fork+exec`. Network timeout hay API lỗi sẽ không bao giờ làm crash tiến trình monitoring lõi.
+
+## 🏗️ Kiến trúc
+
+```mermaid
+graph LR
+    sshd["sshd / sudo / su"]
+    journald[("systemd-journald")]
+    pamsignal["PAMSignal"]
+    admin["🧑‍💻 Admin"]
+    platforms["Telegram / Slack<br/>Teams / WhatsApp / Discord<br/>Custom webhook"]
+    fail2ban["Fail2ban<br/>(iptables / ufw)"]
+
+    sshd -- "PAM auth events" --> journald
+    pamsignal -- "reads & writes<br/>structured events" --> journald
+    admin -- "journalctl -t pamsignal" --> journald
+    pamsignal -. "fork+exec curl<br/>(best-effort)" .-> platforms
+    platforms -. "alerts" .-> admin
+    fail2ban -. "watches pamsignal BRUTE_FORCE_DETECTED events<br/>& blocks attacker IP" .-> journald
+
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style sshd fill:#6c757d,stroke:#495057,color:#fff
+    style platforms fill:#6c757d,stroke:#495057,color:#fff,stroke-dasharray: 5 5
+    style fail2ban fill:#e76f51,stroke:#d62828,color:#fff,stroke-dasharray: 5 5
+    style admin fill:#e9c46a,stroke:#f4a261,color:#000
+```
+
+## 🚀 Bắt đầu nhanh
+
+### 1. Cài đặt
+
+<details>
+<summary><strong>Debian / Ubuntu</strong></summary>
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://anhtuank7c.github.io/pamsignal/key.asc | sudo gpg --dearmor -o /etc/apt/keyrings/pamsignal.gpg
+echo "deb [signed-by=/etc/apt/keyrings/pamsignal.gpg] https://anhtuank7c.github.io/pamsignal stable main" | sudo tee /etc/apt/sources.list.d/pamsignal.list
+sudo apt update && sudo apt install pamsignal
+```
+</details>
+
+<details>
+<summary><strong>Fedora / CentOS / RHEL</strong></summary>
+
+**Fedora / CentOS**
+```bash
+sudo dnf config-manager addrepo --from-repofile=https://anhtuank7c.github.io/pamsignal/rpm/fedora/pamsignal.repo
+sudo dnf install pamsignal
+```
+
+**RHEL 9 / AlmaLinux 9 / Rocky Linux 9**
+```bash
+sudo dnf config-manager --add-repo https://anhtuank7c.github.io/pamsignal/rpm/el9/pamsignal.repo
+sudo dnf install pamsignal
+```
+</details>
+
+<details>
+<summary><strong>Ubuntu 20.04 LTS (Focal, chỉ còn ESM)</strong></summary>
+
+20.04 chỉ còn ESM từ tháng 4/2025 và không có apt pocket trên gh-pages cho nó — nhưng một bản `.deb` nhắm Focal được build và smoke-test trong CI ở mỗi release, rồi đính kèm làm GitHub release asset. Tải về và cài trực tiếp:
+
+```bash
+VERSION=0.5.0   # cập nhật theo từng release — xem https://github.com/anhtuank7c/pamsignal/releases
+curl -fL -o pamsignal_focal.deb \
+  "https://github.com/anhtuank7c/pamsignal/releases/download/v${VERSION}/pamsignal_${VERSION}-1_focal_amd64.deb"
+
+# Tuỳ chọn: verify chữ ký detached (fingerprint của signing key ở bên dưới)
+curl -fL -o pamsignal_focal.deb.asc \
+  "https://github.com/anhtuank7c/pamsignal/releases/download/v${VERSION}/pamsignal_${VERSION}-1_focal_amd64.deb.asc"
+gpg --verify pamsignal_focal.deb.asc pamsignal_focal.deb
+
+# Cài đặt — apt sẽ tự resolve libsystemd0 và các transitive dep từ apt sources của host
+sudo apt install ./pamsignal_focal.deb
+```
+
+Để nâng cấp sau này, chạy lại đúng công thức trên với `VERSION` mới. Với cả một fleet, hãy bọc nó trong một script Ansible / cron / shell nhỏ.
+
+> 🕒 **Nhắc về vòng đời.** Focal kết thúc ESM vào tháng 4/2030. Hãy lên kế hoạch migrate sang 22.04 LTS (Standard Support tới tháng 4/2027) hoặc 24.04 LTS trong khoảng ~12 tháng tới. Xem [docs/distros.md](distros.md) để biết ma trận hỗ trợ đầy đủ.
+</details>
+
+*Fingerprint của signing key: `2D2C 828F A6F4 D019 E446  8FBB B106 2235 2862 2F69`*
+
+### 2. Cấu hình cảnh báo
+
+Sửa file cấu hình (`/etc/pamsignal/pamsignal.conf`) và điền credential nền tảng của bạn. Ví dụ, để bật Telegram:
+
+```ini
+telegram_bot_token = <your_bot_token>
+telegram_chat_id = <your_chat_id>
+```
+*Xem [Hướng dẫn cài đặt cảnh báo](alerts.md) cho Slack, Teams, WhatsApp, và Discord.*
+
+**Hai key tuning đáng biết ngay từ ngày đầu** — một cái điều khiển *tần suất* bạn bị ping, cái kia điều khiển *cái gì* khiến bạn bị ping:
+
+```ini
+# Số giây tối thiểu giữa các brute-force alert cho cùng một IP.
+# Mặc định 60. Đặt 0 để bắn ở MỌI lần vượt ngưỡng —
+# hữu ích cho host ít traffic, nơi bạn không muốn gộp bất kỳ tín hiệu nào.
+alert_cooldown_sec = 60
+
+# Loại sự kiện nào kích hoạt chat alert. Mặc định là "all" (mọi loại),
+# khá ồn trong production. Hãy thu hẹp về đúng thứ bạn quan tâm —
+# phần lớn operator chỉ muốn login thành công và brute-force ping.
+enable_notification_type = login_success,brute_force
+```
+*Cả sáu token loại sự kiện (`login_success`, `login_failed`, `session_open`, `session_close`, `brute_force`, `all`) được tài liệu hoá tại [Configuration → Notification-type filter](configuration.md#bộ-lọc-loại-thông-báo). `journalctl -t pamsignal` vẫn giữ toàn bộ dấu vết forensic bất kể bạn lọc bỏ gì khỏi chat.*
+
+### 3. Tích hợp Custom Webhook (Tuỳ chọn)
+
+Cần gửi cảnh báo tới một provider mà chúng tôi không hỗ trợ sẵn? Hay muốn tự xây logic auto-ban của riêng bạn?
+PAMSignal gửi structured ECS JSON tới bất kỳ custom webhook nào.
+
+👉 **[Xem ví dụ Node.js Custom Webhook](examples/nodejs-webhook.md)** để thấy xây một receiver của riêng bạn dễ thế nào!
+
+### 4. Reload & Theo dõi
+
+Áp dụng cấu hình và xem sự kiện trực tiếp:
+
+```bash
+sudo systemctl reload pamsignal
+journalctl -t pamsignal -f
+```
+
+## 🛡️ Tăng cường với Fail2ban (Bảo vệ nâng cao, tuỳ chọn)
+
+PAMSignal tính sẵn ngưỡng brute-force cho bạn. Bạn có thể tiến thêm một bước bằng cách tự động chặn IP của kẻ tấn công bằng Fail2ban. Vì PAMSignal đã làm phần nặng nhọc, việc cấu hình Fail2ban cực kỳ đơn giản.
+
+👉 **[Đọc hướng dẫn tích hợp Fail2ban](examples/fail2ban.md)**
+
+## 📊 Góc nhìn toàn fleet trong Grafana
+
+`journalctl` theo từng host và chat alert real-time chỉ bao quát một host. Để có fleet-wide auth visibility — một góc nhìn queryable trên mọi server — có sẵn một integration Loki/Alloy/Grafana đi kèm PAMSignal: sự kiện theo schema ECS chảy vào Loki qua Alloy, và một dashboard duy nhất trả lời "đang có gì xảy ra với auth trên cả fleet của tôi ngay lúc này?" chỉ trong một cái liếc.
+
+![PAMSignal Grafana dashboard](../../assets/grafana-dashboard.png)
+
+Stack thử-tại-chỗ (không cần fleet Linux thật):
+
+```bash
+cd examples/grafana && docker compose up -d
+# → http://localhost:3000 (anonymous Admin, dashboard có sẵn)
+```
+
+👉 **[Đọc hướng dẫn tích hợp Grafana](examples/grafana.md)** — deploy đầy đủ + cài Alloy + 4 alert rule
+
+## 📚 Tài liệu
+
+- 🏛️ **[Kiến trúc](architecture.md)** — Sơ đồ C4, mô hình cô lập, và các quyết định thiết kế
+- ⚙️ **[Cấu hình](configuration.md)** — Tham chiếu config, CLI flag, và tuning
+- 🔔 **[Cảnh báo](alerts.md)** — Webhook payload và cài đặt kênh
+- 🔒 **[Triển khai](deployment.md)** — Hardening bảo mật và cấu hình systemd
+- 🎯 **[Threat Model](threat-model.md)** — pamsignal phòng thủ trước cái gì, cố tình không làm gì, và lý do thiết kế đằng sau sự phân tách
+- 📊 **[Tích hợp Grafana](grafana-integration.md)** — Thiết kế dashboard auth toàn fleet (schema, label cardinality, bố cục panel)
+- 🐧 **[Distro được hỗ trợ](distros.md)** — Ma trận ba mức (CI-tested / kỳ vọng chạy được / không hỗ trợ) kèm lý do từng dòng
+- 🛠️ **[Phát triển](development.md)** — Build từ source và testing
+- 🔐 **[Chính sách bảo mật](SECURITY.md)** — Kênh báo lỗi có trách nhiệm và các phiên bản được hỗ trợ
+- 📝 **[Changelog](../../CHANGELOG.md)** — Trạng thái, theo dõi công việc, và cập nhật
+
+---
+
+## 🤖 Xây dựng với sự cộng tác của AI
+
+Dự án này được xây dựng với sự hỗ trợ của AI ([Claude Code](https://claude.ai/claude-code)). Mình công khai về quy trình này: AI bắt các edge case, dẫn dắt quyết định kiến trúc, và thậm chí đã thực hiện [đợt review bảo mật OWASP ASVS 5.0](../../.claude/skills/owasp-review/SKILL.md) giúp hardening dự án. Thư mục `.claude/` được commit vào repo này để bạn có thể kiểm tra chính xác cách AI được sử dụng. Con người test trên hệ thống thật và chịu trách nhiệm cho việc ship.

--- a/docs/vi/SECURITY.md
+++ b/docs/vi/SECURITY.md
@@ -1,0 +1,71 @@
+# Chính Sách Bảo Mật
+
+> 🌐 [English](../../SECURITY.md) · **Tiếng Việt**
+
+PAMSignal là một daemon giám sát bảo mật. Một lỗ hổng trong chính daemon — vượt qua brute-force tracker, giả mạo cảnh báo, log injection, leo thang đặc quyền, memory corruption — được coi là một lỗi ưu tiên cao. Tài liệu này mô tả cách báo cáo riêng tư và những gì bạn có thể mong đợi sau khi báo cáo.
+
+## Báo Cáo Lỗ Hổng
+
+**Vui lòng không tạo một GitHub issue công khai cho các báo cáo bảo mật.** Báo cáo công khai tạo lợi thế cho kẻ tấn công trước khi bản vá được phát hành.
+
+Sử dụng một trong các kênh riêng tư dưới đây:
+
+1. **Ưu tiên — GitHub Security Advisories.** Mở một advisory riêng tư trên repository:
+   <https://github.com/anhtuank7c/pamsignal/security/advisories/new>
+   Thread này vẫn riêng tư cho đến khi cả người báo cáo và người bảo trì đồng ý công bố, và việc yêu cầu gán CVE có thể được thực hiện qua cùng một giao diện.
+
+2. **Email dự phòng** nếu GitHub UI không sử dụng được:
+   `anhtuank7c@hotmail.com` với tiêu đề bắt đầu bằng `[pamsignal-security]`.
+   Mã hóa PGP hiện không bắt buộc, nhưng nếu bạn có thì fingerprint của khóa ký của người bảo trì là `2D2C 828F A6F4 D019 E446  8FBB B106 2235 2862 2F69` (cùng khóa được dùng để ký các package apt + dnf release).
+
+Khi báo cáo, vui lòng bao gồm:
+
+- Phiên bản pamsignal (`pamsignal --version` nếu có, nếu không thì phiên bản package từ `apt show pamsignal` / `dnf info pamsignal`).
+- Bạn tái hiện lỗi từ một `.deb`/`.rpm` đã được phát hành hay từ một source build `meson install`.
+- Chuỗi sự kiện journal / cấu hình tối giản kích hoạt vấn đề, lý tưởng là một unit-test reproducer hoặc một đoạn trích `journalctl --output=export`.
+- Đánh giá của bạn về mức độ nghiêm trọng và các điều kiện tiên quyết để khai thác (người dùng local, cấu hình cụ thể, distro cụ thể, v.v.).
+
+## Lịch Trình Công Bố
+
+- **Xác nhận**: trong vòng 5 ngày làm việc kể từ khi nhận được.
+- **Phân loại và đánh giá mức độ nghiêm trọng**: trong vòng 14 ngày. Người bảo trì sẽ chia sẻ đánh giá và đề xuất lịch trình khắc phục lại cho người báo cáo.
+- **Công bố có phối hợp**: cửa sổ tiêu chuẩn là **90 ngày** từ khi xác nhận đến khi công bố công khai. Người bảo trì sẽ yêu cầu gia hạn (kèm lý do) cho các vấn đề yêu cầu một bản vá phối hợp upstream hoặc migration phức tạp; người báo cáo có quyền từ chối và tiến hành với lịch trình công bố của riêng họ.
+- **Advisory công khai**: được phát hành dưới dạng GitHub Security Advisory + mục trong `CHANGELOG.md` theo release liên quan. Người báo cáo được ghi công trừ khi họ yêu cầu ẩn danh.
+
+## Các Phiên Bản Được Hỗ Trợ
+
+Hai trục:
+
+**Dòng release.** Chỉ dòng release **minor** gần nhất mới nhận được bản vá bảo mật. Các bản vá cho các minor cũ hơn được xem xét từng trường hợp và chỉ khi bản vá rõ ràng trong một dòng — bất kỳ ai chạy project đều nên mong đợi việc nâng cấp lên minor mới nhất để được hỗ trợ bảo mật.
+
+| Phiên bản | Được hỗ trợ |
+|---------|-----------|
+| `0.3.x` | ✅ |
+| `0.2.x` | ❌ (dùng `0.3.x`) |
+| `0.1.x` | ❌ |
+
+Đường cài đặt được khuyến nghị là repository apt hoặc dnf đã được ký, được ghi lại trong [`README.md`](README.md#1-cài-đặt); `apt upgrade` / `dnf upgrade` giữ bạn trên dòng được hỗ trợ một cách tự động.
+
+**Hệ điều hành / distro.** Pamsignal chỉ hỗ trợ Linux hiện đại có systemd gốc. Ma trận distro đầy đủ — các distro được kiểm tra trên CI, các distro dự kiến hoạt động với chú thích từng dòng, và các release không được hỗ trợ rõ ràng với lý do kỹ thuật cho mỗi điểm cut-off — nằm trong [`docs/distros.md`](../../docs/distros.md). Một báo cáo lỗ hổng đối với distro Tier 3 sẽ bị đóng với một con trỏ đến tài liệu đó; các lỗ hổng ảnh hưởng đến distro Tier 1 hoặc Tier 2 nằm trong phạm vi xem xét bảo mật theo chính sách này.
+
+## Phạm Vi
+
+Bảng phân tích đầy đủ trong phạm vi / ngoài phạm vi — bao gồm các khả năng của kẻ tấn công mà daemon giả định, ranh giới tin cậy bên trong codebase, và các lựa chọn thiết kế tạo ra tư thế bảo mật hiện tại — nằm trong [`docs/threat-model.md`](../../docs/threat-model.md). Hãy đọc trước khi báo cáo; đặc biệt, phần "Out of scope" ở đó rất toàn diện về các non-goal (compromised journald / libsystemd / curl, root đã có trên host, alert-provider compromise, multi-host correlation, durable alert delivery, admin misconfiguration).
+
+Tóm tắt, đủ cho hầu hết các báo cáo:
+
+**Trong phạm vi.** Các lỗi memory-safety trong `src/`; các lỗi logic trong `ps_parse_message` vượt qua allowlist `_EXE`; các bypass của brute-force tracker; alert-payload injection (JSON-escape escapes, credential leakage vào argv, URL hijack của `curl` child); các đường leo thang đặc quyền từ user `pamsignal`; các bypass của các directive hardening trong systemd unit.
+
+**Ngoài phạm vi.** Các lỗ hổng trong `curl`, `libsystemd`, journald, hoặc bất kỳ nhà cung cấp alert-channel nào; các threat model yêu cầu root trên host được giám sát; admin misconfiguration; giới hạn tốc độ alert-channel / DoS qua lũ sự kiện hợp pháp.
+
+## Các Biện Pháp Hardening Đã Được Triển Khai
+
+Xem xét các biện pháp phòng thủ hiện có trước khi báo cáo giúp tiết kiệm thời gian cho cả hai bên:
+
+- Allowlist `_EXE` trên mọi journal entry (`src/journal_watch.c`): chỉ các entry có đường dẫn thực thi được ghi nhận phân giải thành `sshd`, `sudo`, `su`, `login`, hoặc `systemd-logind` dưới một system prefix mới được xử lý. Các sự kiện giả mạo từ `logger(1)` bị bỏ qua âm thầm.
+- Compiler hardening (`meson.build`): `-fstack-protector-strong`, `_FORTIFY_SOURCE=3`, `-fcf-protection=full`, `-fstack-clash-protection`, full RELRO, PIE, separate-code, no-exec-stack.
+- Alert dispatch isolation: `fork()` + `execv()` của một `/usr/bin/curl` với đường dẫn tuyệt đối với môi trường đã được `clearenv()`. Webhook URL và bearer token được ghi vào một file `--config` được hỗ trợ bởi `memfd_create()` và truyền qua `/dev/fd/9`; chúng không bao giờ xuất hiện trong argv.
+- systemd unit hardening: `NoNewPrivileges`, `ProtectSystem=strict`, `MemoryDenyWriteExecute`, `RestrictNamespaces`, `SystemCallFilter=@system-service ~@privileged @resources`, `CapabilityBoundingSet=` (trống). Có thể xác minh bằng `systemd-analyze security pamsignal.service`.
+- Fuzzing liên tục: `tests/fuzz_parse_message.c` là một libFuzzer harness tùy chọn cho `ps_parse_message`. Chạy với `meson setup -Dfuzz=enabled build-fuzz` (yêu cầu clang).
+
+Nếu phát hiện của bạn là một cải tiến dựa trên một trong những biện pháp này — ví dụ một trường hợp parser mà fuzz corpus chưa bao phủ, hoặc một khoảng trống syscall-filter — vui lòng nêu rõ điều đó trong báo cáo để bản vá có thể được triển khai cùng với một regression test.

--- a/docs/vi/alerts.md
+++ b/docs/vi/alerts.md
@@ -1,0 +1,350 @@
+# Alerts
+
+> 🌐 [English](../alerts.md) · **Tiếng Việt**
+
+PAMSignal gửi cảnh báo best-effort đến các nền tảng nhắn tin khi phát hiện sự kiện đăng nhập hoặc pattern brute-force. Cảnh báo được gửi qua `fork()+exec(curl)` — một tiến trình con tồn tại trong thời gian ngắn, không thể ảnh hưởng đến quá trình giám sát cốt lõi.
+
+Nếu một cảnh báo thất bại (mạng bị ngắt, lỗi API, timeout), pamsignal ghi log cảnh báo và tiếp tục. Sự kiện luôn được ghi vào journal trước tiên.
+
+## Các kênh hỗ trợ
+
+| Kênh | Các config key cần có |
+|---------|-------------------|
+| Telegram | `telegram_bot_token`, `telegram_chat_id` |
+| Slack | `slack_webhook_url` |
+| Microsoft Teams | `teams_webhook_url` |
+| WhatsApp | `whatsapp_access_token`, `whatsapp_phone_number_id`, `whatsapp_recipient` |
+| Discord | `discord_webhook_url` |
+| Custom webhook | `webhook_url` |
+
+Chỉ cấu hình những kênh bạn sử dụng. PAMSignal gửi đến tất cả các kênh đã có thông tin xác thực. Xem [Configuration](./configuration.md) để biết tham chiếu config đầy đủ.
+
+## Định dạng tin nhắn
+
+Kể từ v0.2.0, các payload cảnh báo tuân theo quy ước [Elastic Common Schema (ECS)]:
+
+- **Các kênh chat** (Telegram / Slack / Teams / WhatsApp / Discord) nhận tin nhắn văn bản một dòng, có tiền tố severity dạng `key=value`.
+- **Custom webhook** nhận một JSON document với các object ECS lồng nhau (`event.*`, `host.*`, `user.*`, `source.*`, `service.*`, `process.*`) cộng với namespace `pamsignal.*` cho các trường riêng của vendor.
+
+Điều này có nghĩa là output của webhook có thể đưa thẳng vào Elastic SIEM và Wazuh mà không cần remapping, và chỉ cần một config Vector / Logstash để kết nối với bất kỳ SIEM hiện đại nào khác.
+
+[Elastic Common Schema (ECS)]: https://www.elastic.co/guide/en/ecs/current/index.html
+
+### Định dạng văn bản chat
+
+Dấu ngoặc severity có độ rộng cố định (8 ký tự) để các cột thẳng hàng khi hiển thị monospace. Thứ tự trường là severity → action → identity → location → metadata → `pid` → `ts`. Trường `pid=` là tiến trình đang chạy cho các sự kiện `session_opened` và `login_success` (bạn có thể `kill <pid>` để ngắt kết nối người dùng) và là auth child đã kết thúc cho các trường hợp thất bại (đã được thu hồi — chỉ hữu ích như thông tin forensics).
+
+```
+[INFO]   auth.session_opened user=root host=web-01 service=sudo pid=12345 ts=2026-03-29T14:23:01+0000 provider=aws service_name=web-api
+[INFO]   auth.session_closed user=root host=web-01 service=sshd pid=12346 ts=2026-03-29T14:25:10+0000 provider=aws service_name=web-api
+[NOTICE] auth.login_success user=admin src=192.168.1.100:52341 host=web-01 service=sshd auth=password pid=12345 ts=2026-03-29T14:23:01+0000
+[WARN]   auth.login_failure user=root src=203.0.113.50:39182 host=web-01 service=sshd auth=password pid=12347 ts=2026-03-29T14:23:01+0000
+[ALERT]  auth.brute_force_detected src=203.0.113.50 attempts=12 window=300s user=root host=web-01 pid=12347 ts=2026-03-29T14:23:01+0000
+[ALERT]  auth.brute_force_detected actor=alice target=root attempts=5 window=300s service=sudo host=web-01 pid=12348 ts=2026-03-29T14:23:01+0000
+```
+
+Dạng cuối cùng được phát ra khi một user nội bộ (`alice`) liên tục thất bại khi xác thực qua `sudo`/`su` trên host. Không có `src=` vì thao tác không có remote endpoint; ECS `user.name` mang tên actor và `user.target.name` là mục tiêu leo thang quyền. Cảnh báo `auth.login_failure` theo từng sự kiện **không** được phát cho sudo/su — chỉ có cảnh báo brute-force tổng hợp mới được gửi, để một lần gõ sai mật khẩu không làm phiền operator. Tuy nhiên, bản ghi journal từ `pamsignal` vẫn được ghi cho mỗi lần thất bại riêng lẻ.
+
+*(Lưu ý: Các tag context tùy chỉnh như `provider=aws service_name=web-api` sẽ tự động được thêm vào nếu được cấu hình trong `pamsignal.conf`)*
+
+### Telegram
+
+Gửi dưới dạng plain text qua [Bot API `sendMessage`](https://core.telegram.org/bots/api#sendmessage). Cùng định dạng văn bản chat một dòng như trên.
+
+**Cài đặt:**
+1. Tạo bot với [@BotFather](https://t.me/BotFather) và sao chép token
+2. Thêm bot vào group/channel của bạn
+3. Lấy chat ID (gửi một tin nhắn, sau đó kiểm tra `https://api.telegram.org/bot<token>/getUpdates`)
+4. Đặt `telegram_bot_token` và `telegram_chat_id` trong `pamsignal.conf`
+
+### Slack
+
+Gửi dưới dạng tin nhắn một dòng qua [incoming webhook](https://api.slack.com/messaging/webhooks). Cùng định dạng văn bản chat.
+
+**Cài đặt:**
+1. Vào [Slack App Directory](https://api.slack.com/apps) và tạo một app
+2. Bật **Incoming Webhooks** và tạo webhook cho channel của bạn
+3. Đặt `slack_webhook_url` trong `pamsignal.conf`
+
+### Microsoft Teams
+
+Gửi dưới dạng plain text qua [incoming webhook connector](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook).
+
+**Cài đặt:**
+1. Trong Teams channel của bạn, vào **Channel settings > Connectors > Incoming Webhook**
+2. Đặt `teams_webhook_url` trong `pamsignal.conf`
+
+### WhatsApp
+
+Gửi dưới dạng plain text qua [Meta WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api).
+
+**Cài đặt:**
+1. Tạo [Meta Business app](https://developers.facebook.com/apps/) và thêm WhatsApp
+2. Lấy **Phone Number ID** và tạo **permanent access token**
+3. Đặt `whatsapp_access_token`, `whatsapp_phone_number_id` và `whatsapp_recipient` trong `pamsignal.conf`
+
+> **Lưu ý:** WhatsApp Cloud API yêu cầu tài khoản Meta Business đã xác minh cho mục đích sử dụng thực tế (production).
+
+### Discord
+
+Gửi dưới dạng plain text qua [Discord webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
+
+**Cài đặt:**
+1. Trong Discord channel của bạn, vào **Settings > Integrations > Webhooks > New Webhook**
+2. Đặt `discord_webhook_url` trong `pamsignal.conf`
+
+### Custom webhook (ECS JSON)
+
+Gửi dưới dạng request `POST` với `Content-Type: application/json`. Tuân theo ECS nên có thể đưa vào Elastic Stack, Wazuh, hoặc bất kỳ pipeline nào hỗ trợ ECS mà không cần remapping trường.
+
+> 💡 **Muốn xây dựng receiver của riêng bạn?** Tham khảo **[Node.js Express Webhook Example](examples/nodejs-webhook.md)** sẵn sàng triển khai! Nó minh họa cách xác thực, phân tích cú pháp ECS JSON payload, và định tuyến các sự kiện PAMSignal.
+
+**Sự kiện đăng nhập:**
+
+```json
+{
+  "@timestamp": "2026-03-29T14:23:01+0000",
+  "event": {
+    "action": "login_failure",
+    "category": ["authentication"],
+    "kind": "event",
+    "outcome": "failure",
+    "severity": 5,
+    "module": "pamsignal",
+    "dataset": "pamsignal.events"
+  },
+  "host": {"hostname": "web-01"},
+  "user": {"name": "root"},
+  "service": {"name": "sshd"},
+  "source": {"ip": "203.0.113.50", "port": 39182},
+  "process": {"pid": 12347, "user": {"id": "0"}},
+  "pamsignal": {
+    "event_type": "LOGIN_FAILED",
+    "auth_method": "password"
+  },
+  "labels": {
+    "provider": "aws",
+    "service_name": "database"
+  }
+}
+```
+
+*(Lưu ý: Object `labels` chỉ được đưa vào nếu bạn đã định nghĩa `provider` hoặc `service_name` trong `pamsignal.conf`)*
+
+**Sự kiện session** (không có `source.*` vì đây không phải sự kiện mạng):
+
+```json
+{
+  "@timestamp": "2026-03-29T14:23:01+0000",
+  "event": {
+    "action": "session_opened",
+    "category": ["authentication", "session"],
+    "kind": "event",
+    "outcome": "success",
+    "severity": 3,
+    "module": "pamsignal",
+    "dataset": "pamsignal.events"
+  },
+  "host": {"hostname": "web-01"},
+  "user": {"name": "root"},
+  "service": {"name": "sudo"},
+  "process": {"pid": 12345, "user": {"id": "0"}},
+  "pamsignal": {"event_type": "SESSION_OPEN"}
+}
+```
+
+**Phát hiện brute-force — từ xa (sshd, hoặc sudo/su có `rhost=`)**: được đánh key theo source IP, `event.kind=alert`, severity 8:
+
+```json
+{
+  "@timestamp": "2026-03-29T14:23:01+0000",
+  "event": {
+    "action": "brute_force_detected",
+    "category": ["authentication", "intrusion_detection"],
+    "kind": "alert",
+    "outcome": "unknown",
+    "severity": 8,
+    "module": "pamsignal",
+    "dataset": "pamsignal.events"
+  },
+  "host": {"hostname": "web-01"},
+  "user": {"name": "root"},
+  "source": {"ip": "203.0.113.50"},
+  "process": {"pid": 12347},
+  "pamsignal": {
+    "event_type": "BRUTE_FORCE_DETECTED",
+    "attempts": 12,
+    "window_sec": 300
+  }
+}
+```
+
+**Phát hiện brute-force — nội bộ (sudo/su không có remote endpoint)**: được đánh key theo actor (`ruser=`), không có `source.*`. `user.name` là actor; `user.target.name` là mục tiêu leo thang quyền:
+
+```json
+{
+  "@timestamp": "2026-03-29T14:23:01+0000",
+  "event": {
+    "action": "brute_force_detected",
+    "category": ["authentication", "intrusion_detection"],
+    "kind": "alert",
+    "outcome": "unknown",
+    "severity": 8,
+    "module": "pamsignal",
+    "dataset": "pamsignal.events"
+  },
+  "host": {"hostname": "web-01"},
+  "user": {"name": "alice", "target": {"name": "root"}},
+  "service": {"name": "sudo"},
+  "process": {"pid": 12348},
+  "pamsignal": {
+    "event_type": "BRUTE_FORCE_DETECTED",
+    "attempts": 5,
+    "window_sec": 300
+  }
+}
+```
+
+**Chi tiết HTTP:**
+
+| Thuộc tính | Giá trị |
+|----------|-------|
+| Method | `POST` |
+| Content-Type | `application/json` |
+| Response mong đợi | `2xx` (non-2xx được ghi log như cảnh báo) |
+
+**Xác thực (tùy chọn):**
+
+Đặt `webhook_auth_header` trong `pamsignal.conf` để gửi một HTTP header tùy ý kèm theo mỗi POST:
+
+```ini
+webhook_url = https://siem.example.com/ingest/pamsignal
+webhook_auth_header = Authorization: Bearer s3cr3t-token-here
+```
+
+Các pattern phổ biến:
+
+| Receiver | Header |
+|----------|--------|
+| Bearer / OAuth | `Authorization: Bearer <token>` |
+| Generic API key | `X-API-Key: <key>` |
+| Splunk HEC | `Authorization: Splunk <token>` |
+| Datadog Logs | `DD-API-KEY: <key>` |
+| Wazuh API | `Authorization: Bearer <jwt>` |
+
+Giá trị header được truyền cho curl qua một curl `-K` config file backed bởi memfd, nên secret không bao giờ xuất hiện trong `argv`, `/proc/<pid>/cmdline`, hay bất kỳ danh sách tiến trình nào. Chỉ hỗ trợ một header; các giá trị chứa `\r`, `\n`, `"` hoặc `\` đều bị từ chối khi load config.
+
+**Mutual TLS (tùy chọn, nâng cao):**
+
+Đối với các môi trường đã có PKI (internal CA, cert-manager, SPIFFE, service-mesh issuance), pamsignal có thể xác thực với receiver bằng client certificate. Mạnh hơn xác thực bằng shared-secret: private key không bao giờ truyền qua mạng, và việc xoay vòng thông tin xác thực được giao cho pipeline cert-management.
+
+```ini
+webhook_url = https://siem.internal.example.com/ingest
+webhook_client_cert = /etc/pamsignal/webhook-client.crt
+webhook_client_key  = /etc/pamsignal/webhook-client.key
+# Optional: only if the receiver's CA isn't in the system trust store
+webhook_ca_bundle   = /etc/pamsignal/webhook-ca.pem
+```
+
+mTLS kết hợp cộng thêm với `webhook_auth_header` — các operator có receiver như Wazuh API hay SIEM gateway doanh nghiệp thường yêu cầu cả hai (mTLS cho xác thực danh tính service ở tầng transport, Bearer cho rate-limit / multi-tenancy ở tầng ứng dụng).
+
+**Yêu cầu vận hành:**
+
+- `webhook_client_cert` và `webhook_client_key` phải được đặt cùng nhau; đặt một cái mà không có cái kia là lỗi load config.
+- `webhook_client_key` không được phép đọc bởi group hoặc other. Layout khuyến nghị: `0640 root:pamsignal` (hoặc `0600 pamsignal:pamsignal` nếu daemon chạy unprivileged), tương tự như bảo vệ trên chính `pamsignal.conf`.
+- Cả ba đường dẫn đều được mở với `O_NOFOLLOW` (symlink bị từ chối) và phải là file thường thuộc sở hữu của `root` hoặc daemon user.
+- Các giá trị đường dẫn chứa `\r`, `\n`, `"` hoặc `\` đều bị từ chối khi load config.
+- Khóa mã hóa (protected bằng passphrase) không được hỗ trợ. Hãy dùng quyền filesystem, `systemd-creds`, hoặc mô hình secret injection của cert manager.
+- Đường dẫn cert/key được đưa qua cùng curl config backed bởi memfd như auth header, nên chúng cũng không xuất hiện trong `argv` — giữ cho process listing của alert child ở mức tối thiểu.
+
+### Các loại sự kiện
+
+| `event.action` (ECS) | `pamsignal.event_type` (legacy) | Khi nào | Severity | Token `enable_notification_type` |
+|---|---|---|---|---|
+| `session_opened` | `SESSION_OPEN` | PAM session mở ra (sshd / sudo / su / login) | 3 (info) | `session_open` |
+| `session_closed` | `SESSION_CLOSE` | PAM session đóng lại | 3 (info) | `session_close` |
+| `login_success` | `LOGIN_SUCCESS` | Xác thực SSH thành công (mật khẩu hoặc public key) | 4 (notice) | `login_success` |
+| `login_failure` | `LOGIN_FAILED` | Xác thực SSH thất bại | 5 (warning) | `login_failed` |
+| `login_failure` (sudo/su) | `LOGIN_FAILED` | Thao tác sudo/su thất bại — **chỉ ghi journal** (không gửi cảnh báo chat theo từng sự kiện; được tính vào ngưỡng brute-force) | 5 (warning) | `login_failed` (chặn lọc riêng vẫn được áp dụng) |
+| `brute_force_detected` | `BRUTE_FORCE_DETECTED` | Số lần thất bại từ một IP **hoặc** từ một actor nội bộ (sudo/su) vượt ngưỡng trong cửa sổ thời gian | 8 (alert) | `brute_force` |
+
+Cột cuối cùng là token cần liệt kê trong `enable_notification_type` để nhận loại sự kiện đó dưới dạng cảnh báo chat. Mặc định (`all`, hoặc bỏ qua key) bật mọi loại. Bộ lọc chỉ kiểm soát việc gửi chat — `journalctl -t pamsignal` ghi lại mọi sự kiện bất kể cài đặt. Xem [Configuration → Bộ lọc loại thông báo](./configuration.md#bộ-lọc-loại-thông-báo) để biết tham chiếu đầy đủ.
+
+### Tham chiếu trường (ECS webhook JSON)
+
+| Đường dẫn | Kiểu | Có mặt trong | Mô tả |
+|---|---|---|---|
+| `@timestamp` | string | Tất cả | ISO 8601 với timezone offset |
+| `event.action` | string | Tất cả | Một trong các giá trị trong bảng trên |
+| `event.category` | array&lt;string&gt; | Tất cả | Luôn có `"authentication"`; session thêm `"session"`, brute-force thêm `"intrusion_detection"` |
+| `event.kind` | string | Tất cả | `"event"` cho quan sát, `"alert"` cho brute-force |
+| `event.outcome` | string | Tất cả | `"success"`, `"failure"` hoặc `"unknown"` |
+| `event.severity` | integer | Tất cả | 3=info, 4=notice, 5=warning, 8=alert |
+| `event.module` | string | Tất cả | Luôn là `"pamsignal"` |
+| `event.dataset` | string | Tất cả | Luôn là `"pamsignal.events"` |
+| `host.hostname` | string | Tất cả | Hostname của server |
+| `user.name` | string | Tất cả | Tên người dùng từ thông điệp PAM |
+| `service.name` | string | Login/Session | PAM service: `sshd`, `sudo`, `su`, `login`, `other` |
+| `source.ip` | string | Login + Brute | Remote IP (được xác thực qua `inet_pton`) |
+| `source.port` | integer | Login | Remote port |
+| `process.pid` | integer | Tất cả | Process ID — sshd session đang chạy cho `login_success`/`session_opened`, auth child (đã kết thúc) cho các trường hợp thất bại và brute-force |
+| `process.user.id` | string | Login/Session | UID của tiến trình được PAM xử lý |
+| `pamsignal.event_type` | string | Tất cả | Legacy uppercase enum (giữ để tương thích ngược cho đến v0.2.x; bỏ trong v0.3.0) |
+| `pamsignal.auth_method` | string | Login | `password`, `publickey` hoặc `unknown` |
+| `pamsignal.attempts` | integer | Brute-force | Số lần thất bại đã vượt ngưỡng |
+| `pamsignal.window_sec` | integer | Brute-force | Cửa sổ thời gian đã cấu hình |
+
+### Tương thích SIEM
+
+ECS payload có thể dùng ngay với:
+
+- **Elastic SIEM** — schema là native; không cần remapping
+- **Wazuh** — template wazuh-indexer nhận trực tiếp các sự kiện dạng ECS
+- **Sumo Logic, Datadog, Graylog, Loki** — schema linh hoạt; index bất kỳ JSON nào bạn gửi
+
+Cần một bước mapping một lần (Vector / Logstash / Filebeat processor, hoặc pipeline riêng của SIEM) cho:
+
+- **Splunk** — cài [Add-on for Elastic Common Schema] để ánh xạ ECS sang Splunk CIM, hoặc POST lên HEC và viết một Splunk macro tuân theo CIM
+- **Microsoft Sentinel** — viết một [KQL parse function](https://learn.microsoft.com/azure/sentinel/normalization-about-parsers) dịch ECS sang ASIM
+- **AWS Security Hub** — dịch sang [ASFF] trước khi chuyển tiếp
+
+Đối với các SIEM doanh nghiệp cũ ưa dùng CEF (ArcSight) hoặc LEEF (IBM QRadar), dùng Vector hoặc Logstash để remap các trường ECS. (Chế độ output CEF native nằm trong roadmap nếu có đủ nhu cầu.)
+
+[Add-on for Elastic Common Schema]: https://splunkbase.splunk.com/app/4848
+[ASFF]: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html
+
+### Kiến trúc production
+
+Hầu hết SIEM production không nhận webhook trực tiếp. Luồng thông thường là:
+
+```
+pamsignal --HTTP--> ingest layer (Vector / Fluent Bit / Logstash) --> SIEM
+```
+
+Ví dụ cấu hình Vector nhận từ pamsignal và chuyển tiếp đến Elastic:
+
+```toml
+[sources.pamsignal]
+type = "http_server"
+address = "0.0.0.0:8080"
+encoding = "json"
+
+[sinks.elastic]
+type = "elasticsearch"
+inputs = ["pamsignal"]
+endpoints = ["https://es.example.com:9200"]
+api_version = "v8"
+```
+
+Cùng pattern này áp dụng cho bất kỳ SIEM nào không dùng ECS — thêm bước `transforms.remap` giữa source và sink để đổi tên trường.
+
+## Cơ chế cách ly cảnh báo hoạt động như thế nào
+
+Xem [Architecture — Alert isolation model](./architecture.md#mô-hình-cô-lập-cảnh-báo) để có giải thích đầy đủ. Tóm tắt:
+
+1. Sự kiện **luôn được ghi vào journal trước** (bản ghi cốt lõi được lưu trữ)
+2. Tiến trình cha `fork()` một tiến trình con
+3. Tiến trình con `exec("curl", ...)` gửi HTTP request
+4. Tiến trình cha tiếp tục event loop ngay lập tức — không chờ đợi
+5. Nếu tiến trình con bị crash hoặc mạng bị ngắt — tiến trình cha không bị ảnh hưởng
+6. Không có HTTP library nào tồn tại trong tiến trình cha

--- a/docs/vi/architecture.md
+++ b/docs/vi/architecture.md
@@ -1,0 +1,245 @@
+# Architecture
+
+> 🌐 [English](../architecture.md) · **Tiếng Việt**
+
+PAMSignal được thiết kế xung quanh một nguyên tắc cốt lõi: **làm tốt một việc với ít thành phần chuyển động nhất có thể.**
+
+Nó đăng ký theo dõi systemd journal, lọc các thông báo liên quan đến PAM từ sshd, sudo, su và login, phân tích từng thông báo để trích xuất dữ liệu có cấu trúc (tên người dùng, địa chỉ IP nguồn, cổng, dịch vụ, phương thức xác thực), rồi ghi lại các sự kiện có cấu trúc trở lại journal với các trường tùy chỉnh. Nó theo dõi các lần đăng nhập thất bại theo IP và phát hiện các mẫu brute-force. Tuỳ chọn, nó gửi các cảnh báo best-effort đến các nền tảng nhắn tin mà không gây rủi ro cho việc giám sát cốt lõi.
+
+Single binary. Single config file. Single dependency (`libsystemd`). Không database, không web server, không relay process riêng biệt.
+
+## C4 Model
+
+Theo quy ước [C4 model](https://c4model.com/), chúng ta ánh xạ kiến trúc từ tổng quan hệ thống cấp cao xuống các thành phần nội bộ.
+
+### Level 1: System Context
+
+Sơ đồ System Context cung cấp cái nhìn tổng quan cấp cao về cách người dùng tương tác với các hệ thống nội bộ và bên ngoài để nhận giá trị. Nó cho thấy PAMSignal trong môi trường máy chủ Linux rộng hơn.
+
+```mermaid
+C4Context
+  title System Context diagram for PAMSignal
+
+  Person(admin, "System Administrator", "A sysadmin who monitors and secures the server")
+  
+  System(pamsignal, "PAMSignal", "Real-time PAM event monitor and alert dispatcher")
+  
+  System_Ext(sshd, "PAM Services", "sshd, sudo, su, login")
+  System_Ext(journald, "systemd-journald", "Centralized binary logging system")
+  System_Ext(platforms, "Messaging Platforms", "Telegram, Slack, Teams, WhatsApp, Discord, Webhooks")
+  System_Ext(fail2ban, "Fail2ban", "Intrusion prevention system (iptables / ufw)")
+
+  Rel(sshd, journald, "Writes PAM auth events to")
+  Rel(pamsignal, journald, "Reads PAM events & writes structured alerts to")
+  Rel(admin, journald, "Queries structured events via journalctl")
+  Rel(pamsignal, platforms, "Dispatches alerts via curl", "HTTPS")
+  Rel(platforms, admin, "Delivers alert messages to")
+  Rel(fail2ban, journald, "Watches for pamsignal BRUTE_FORCE_DETECTED events")
+```
+
+### Level 2: Container
+
+Sơ đồ Container phóng to vào ranh giới hệ thống để hiển thị các container có thể chạy/triển khai độc lập. PAMSignal là một daemon đơn tiến trình. Các cảnh báo được gửi bởi các tiến trình con (`curl`) có thời gian sống ngắn và không thể ảnh hưởng đến daemon giám sát cha.
+
+```mermaid
+C4Container
+  title Container diagram for PAMSignal
+  
+  Person(admin, "System Administrator", "A sysadmin who monitors the server")
+  
+  System_Boundary(server, "Linux Server") {
+      System_Ext(sshd, "PAM Services", "sshd, sudo, su, login")
+      System_Ext(journald, "systemd-journald", "Structured binary log")
+      System_Ext(systemd, "systemd", "Service manager")
+      System_Ext(fail2ban, "Fail2ban", "Intrusion prevention framework")
+      
+      Container(daemon, "PAMSignal Daemon", "C / libsystemd", "Core monitoring process running as an unprivileged service")
+      Container(curl, "curl Child Process", "cURL", "Short-lived fire-and-forget alert dispatcher")
+  }
+  
+  System_Ext(platforms, "External Platforms", "Telegram, Slack, Teams, WhatsApp, Discord, Webhook")
+
+  Rel(sshd, journald, "Writes auth events to")
+  Rel(daemon, journald, "Reads events & writes structured alerts to")
+  Rel(systemd, daemon, "Starts, stops, sandboxes")
+  Rel(admin, journald, "Queries logs via journalctl")
+  Rel(daemon, curl, "fork() & exec()", "Process creation")
+  Rel(curl, platforms, "POSTs JSON/text alerts to", "HTTPS")
+  Rel(fail2ban, journald, "Watches BRUTE_FORCE_DETECTED events")
+```
+
+### Level 3: Component
+
+Sơ đồ Component phóng to vào container PAMSignal daemon để hiển thị các thành phần C nội bộ, ánh xạ đến các file source thực tế trong dự án.
+
+```mermaid
+C4Component
+  title Component diagram for PAMSignal Daemon
+  
+  Container_Ext(journald, "systemd-journald", "System log service")
+  Container_Ext(curl, "curl Child Process", "cURL binary")
+
+  Container_Boundary(daemon, "PAMSignal Daemon") {
+      Component(main, "main.c", "C", "CLI parsing, root rejection, journal group check, daemon lifecycle")
+      Component(config, "config.c", "C", "INI parser, validation, SIGHUP reload support")
+      Component(init, "init.c", "C", "Double-fork daemonization, signal handling, PID file")
+      Component(jw, "journal_watch.c", "C", "Journal subscription, event loop, brute-force state tracking")
+      Component(utils, "utils.c", "C", "PAM message parsing, IP validation, log sanitization")
+      Component(notify, "notify.c", "C", "Alert formatting and fork+exec dispatch")
+  }
+
+  Rel(main, config, "Loads config using")
+  Rel(main, init, "Initializes daemon using")
+  Rel(main, jw, "Starts event loop in")
+  Rel(jw, utils, "Parses messages using")
+  Rel(jw, config, "Reloads on SIGHUP using")
+  
+  Rel(jw, journald, "Reads PAM events & writes structured alerts via sd_journal_send")
+  Rel(jw, notify, "Triggers alerts via")
+  Rel(notify, curl, "fork+exec() (fire-and-forget)")
+```
+
+## Data flow
+
+```
+SSH login attempt
+    → sshd writes to journald
+        → pamsignal reads via sd_journal_wait/next
+            → utils.c parses message, extracts fields
+                → journal_watch.c writes structured event via sd_journal_send
+                    → journald stores event with custom fields
+                        → admin reads with: journalctl -t pamsignal
+                → notify.c fork() → child exec("curl", ...) → Telegram/Slack/etc.
+                    → parent continues immediately (fire-and-forget)
+                    → child exits on its own (success or failure)
+```
+
+## Mô hình cô lập cảnh báo
+
+Các cảnh báo là **best-effort và không thể làm gián đoạn việc giám sát cốt lõi**. Đây là cách hoạt động:
+
+```mermaid
+graph LR
+    subgraph parent ["PAMSignal (parent process)"]
+        event["Event detected"]
+        write_journal["Write to journal"]
+        do_fork["fork()"]
+        continue["Continue event loop"]
+    end
+
+    subgraph child ["Child process (short-lived)"]
+        exec_curl["exec curl"]
+        send["HTTP POST"]
+        exit_child["exit"]
+    end
+
+    event --> write_journal
+    write_journal --> do_fork
+    do_fork --> continue
+    do_fork -. "child" .-> exec_curl
+    exec_curl --> send
+    send --> exit_child
+
+    style parent fill:#f8f9fa,stroke:#2d6a4f,color:#000
+    style child fill:#f8f9fa,stroke:#7f5539,color:#000,stroke-dasharray: 5 5
+    style event fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style write_journal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style do_fork fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style continue fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style exec_curl fill:#7f5539,stroke:#6c584c,color:#fff
+    style send fill:#7f5539,stroke:#6c584c,color:#fff
+    style exit_child fill:#7f5539,stroke:#6c584c,color:#fff
+```
+
+**Tại sao thiết kế này an toàn:**
+
+1. Tiến trình cha **luôn ghi vào journal trước** — bản ghi cốt lõi được lưu trữ trước khi có bất kỳ nỗ lực cảnh báo nào
+2. `fork()` tạo ra một tiến trình con copy-on-write — nhẹ trên Linux, không có trạng thái chia sẻ
+3. Tiến trình cha **không chờ** tiến trình con — nó tiếp tục vòng lặp sự kiện ngay lập tức
+4. Nếu tiến trình con bị crash, segfault hoặc treo — tiến trình cha hoàn toàn không bị ảnh hưởng
+5. Nếu Telegram/Slack/Discord bị sập — tiến trình con timeout và thoát, pamsignal tiếp tục giám sát
+6. `SIGCHLD` bị bỏ qua (`SA_NOCLDWAIT`) nên các zombie process được tự động thu dọn
+7. Tiến trình con `exec` `curl` — không có HTTP library nào được link vào tiến trình cha
+
+### Cách gọi curl (config dùng memfd)
+
+Mỗi sender theo kênh — Telegram, Slack/Teams/Discord, WhatsApp, custom webhook — đều đi qua một điểm vào nội bộ duy nhất (`post_alert` trong `src/notify.c`) — điểm này ghi cấu hình per-request vào một file được tạo bởi `memfd_create()` trong bộ nhớ và truyền cho curl dưới dạng `-K /dev/fd/9`. Memfd có bit CLOEXEC được xóa bằng `dup2`; mọi file descriptor kế thừa khác đều được đóng trong tiến trình con trước khi `execv`.
+
+Nội dung trong memfd config:
+
+- `url = "<endpoint>"` — luôn có mặt.
+- `header = "<full Name: value>"` — có khi kênh cần auth header. WhatsApp dùng nội bộ cho Meta Cloud API Bearer; kênh custom-webhook dùng cho `webhook_auth_header`.
+- `cert = "<path>"`, `key = "<path>"`, `cacert = "<path>"` — có khi kênh custom-webhook được cấu hình mTLS. Bản thân các đường dẫn không phải bí mật (nội dung file mới là bí mật, và nằm trên đĩa trong ranh giới tin cậy của daemon), nhưng việc định tuyến chúng qua cùng memfd config giúp `argv` của tiến trình con curl tối giản và nhất quán bất kể có bao nhiêu tùy chọn xác thực được cấu hình.
+
+Hiệu ứng trên `/proc/<pid>/cmdline` của tiến trình con curl: mỗi lần gửi cảnh báo đều tạo ra một `argv` là `curl -s -S --max-time 10 --proto =https --proto-redir =https -H "Content-Type: application/json" -K /dev/fd/9 -d <body>`, byte-identical dù là kênh nào hay chế độ xác thực nào đang được dùng. Một người dùng không có đặc quyền đọc `/proc/*/cmdline` không thể biết từ command line liệu có token, client cert, hay cả hai được cấu hình, chứ chưa nói đến việc thu thập các giá trị đó.
+
+Các flag `--proto =https` / `--proto-redir =https` vẫn ở trên `argv` (không nằm trong file config) để có thể kiểm tra từ bên ngoài như một đảm bảo hardening — bất kỳ ai xem xét tiến trình đang chạy đều có thể xác nhận rằng các scheme cleartext / non-HTTPS bị từ chối ngay cả trước cổng validator.
+
+## Các trường journal có cấu trúc
+
+PAMSignal ghi sự kiện bằng `sd_journal_send()` với tên trường được căn chỉnh theo [Elastic Common Schema (ECS)] để các công cụ SIEM hiện có có thể ingest journal trực tiếp qua tên trường ECS chuẩn thay vì một từ điển riêng của nhà cung cấp. (Từ series v0.2.x, PAMSignal cũng phát ra song song bộ trường `PAMSIGNAL_*`; các trường legacy đó đã bị loại bỏ trong v0.3.0 — hãy cập nhật mọi query `journalctl PAMSIGNAL_EVENT=…` sang các dạng ECS bên dưới.)
+
+Cho các sự kiện login / session:
+
+| Trường | Ví dụ | Mô tả |
+|-------|---------|-------------|
+| `EVENT_ACTION` | `login_failure` | Một trong: `session_opened`, `session_closed`, `login_success`, `login_failure`, `brute_force_detected` |
+| `EVENT_CATEGORY` | `authentication` | Danh sách phân cách bằng dấu phẩy; session thêm `session`, brute-force thêm `intrusion_detection` |
+| `EVENT_KIND` | `event` | `event` cho quan sát, `alert` cho brute-force |
+| `EVENT_OUTCOME` | `failure` | `success`, `failure`, hoặc `unknown` |
+| `EVENT_SEVERITY` | `5` | 3=info, 4=notice, 5=warning, 8=alert |
+| `EVENT_MODULE` | `pamsignal` | Luôn là `pamsignal` |
+| `USER_NAME` | `root` | Với sshd là tài khoản bị tấn công; với sudo/su là actor cục bộ (`ruser`) |
+| `SOURCE_IP` | `203.0.113.45` | IP từ xa (đã được xác thực). Trống / vắng mặt với brute-force sudo/su thuần cục bộ |
+| `SOURCE_PORT` | `22` | Cổng từ xa (chỉ với sự kiện login) |
+| `SERVICE_NAME` | `sshd` | PAM service: `sshd`, `sudo`, `su`, `login`, `other` |
+| `HOST_HOSTNAME` | `web-01` | Hostname của máy chủ |
+| `PROCESS_PID` | `12345` | PID của sshd / sudo / su liên quan đến sự kiện |
+
+Với các sự kiện brute-force, bộ `EVENT_*` tương tự được áp dụng, thêm vào đó — chỉ với biến thể local-actor — là `USER_TARGET_NAME` (ví dụ: `root`) — người dùng mà actor đang cố leo thang đặc quyền đến.
+
+Ví dụ query:
+
+```bash
+# All pamsignal events
+journalctl -t pamsignal
+
+# Only failed logins
+journalctl -t pamsignal EVENT_ACTION=login_failure
+
+# Only brute-force alerts (both IP-keyed and local-actor-keyed)
+journalctl -t pamsignal EVENT_ACTION=brute_force_detected
+
+# Events from a specific IP
+journalctl -t pamsignal SOURCE_IP=203.0.113.45
+
+# JSON output (for scripting)
+journalctl -t pamsignal -o json
+```
+
+[Elastic Common Schema (ECS)]: https://www.elastic.co/guide/en/ecs/current/index.html
+
+## Quyết định thiết kế
+
+**Tại sao dùng systemd journal làm đầu ra chính?**
+Journal đã có sẵn ở đó. Nó cung cấp các trường có cấu trúc, kiểm soát truy cập, persistence và rotation. Quản trị viên có thể query bằng filter `journalctl`. Script có thể tiêu thụ đầu ra JSON. Không có định dạng log tùy chỉnh nào cần duy trì.
+
+**Tại sao dùng fork+exec curl cho cảnh báo (không dùng libcurl, không dùng relay riêng)?**
+Ba mối quan tâm được cân bằng:
+- **Khả năng sử dụng:** Một binary, một config file. Không Python, không pip, không service thứ hai để quản lý.
+- **Cô lập:** Crash của tiến trình con không ảnh hưởng đến tiến trình cha. Không có HTTP library nào trong không gian địa chỉ của tiến trình cha.
+- **Đơn giản:** `curl` được cài sẵn trên mọi máy chủ Linux. Không có dependency mới nào để biên dịch hay link.
+
+Một relay riêng (journal subscriber bằng Python) là cách tiếp cận kiến trúc thuần khiết nhất nhưng làm đôi độ phức tạp vận hành. Fork+exec đạt được sự cô lập lỗi tương tự với zero độ phức tạp phía người dùng.
+
+**Tại sao không chạy bằng root?**
+Daemon chỉ cần đọc journal. Chạy bằng root sẽ mở rộng bề mặt tấn công mà không mang lại lợi ích gì. Group `systemd-journal` cấp quyền đọc.
+
+**Tại sao dùng bảng fail tĩnh (không phải hash map)?**
+Bảng bị giới hạn ở `max_tracked_ips` mục (mặc định 256). Một mảng phẳng với linear scan đơn giản hơn, không có overhead từ allocator, và đủ nhanh cho quy mô này. Nếu bạn theo dõi 100.000 IP, bạn cần một công cụ khác.
+
+**Tại sao dùng INI config (không phải YAML/JSON)?**
+Không cần dependency. Config có khoảng 10 key — thư viện phân tích YAML/JSON thêm độ phức tạp mà không mang lại lợi ích gì. Quản trị viên có thể chỉnh sửa nó bằng `vi` trong 10 giây.
+
+**Tại sao không có network code trong tiến trình cha?**
+Mọi dependency mạng (libcurl, socket, TLS) đều là bề mặt tấn công. Một công cụ giám sát bảo mật nên tối thiểu hóa bề mặt tấn công của chính nó. Tiến trình cha đọc từ journal, ghi vào journal, và fork các tiến trình con cho cảnh báo. Các tiến trình con exec `curl` và thoát. Tiến trình cha không bao giờ thực hiện cuộc gọi mạng.

--- a/docs/vi/configuration.md
+++ b/docs/vi/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+> 🌐 [English](../configuration.md) · **Tiếng Việt**
+
+`/etc/pamsignal/pamsignal.conf` — định dạng INI, không phụ thuộc thư viện ngoài. Tất cả các giá trị đều là tùy chọn; nếu file bị thiếu hoặc một key không có mặt, các giá trị mặc định hợp lý sẽ được áp dụng.
+
+Vì file này có thể chứa thông tin xác thực của các kênh cảnh báo, quyền truy cập cần được giới hạn:
+
+```bash
+sudo chown root:pamsignal /etc/pamsignal/pamsignal.conf
+sudo chmod 0640 /etc/pamsignal/pamsignal.conf
+```
+
+## Tham chiếu đầy đủ
+
+```ini
+# Brute-force detection
+fail_threshold = 5
+fail_window_sec = 300
+max_tracked_ips = 256
+alert_cooldown_sec = 60
+
+# Chat-dispatch filter (default: all)
+enable_notification_type = all
+
+# Telegram
+telegram_bot_token = <bot_token>
+telegram_chat_id = <chat_id>
+
+# Slack
+slack_webhook_url = <webhook_url>
+
+# Microsoft Teams
+teams_webhook_url = <webhook_url>
+
+# WhatsApp (Meta Cloud API)
+whatsapp_access_token = <access_token>
+whatsapp_phone_number_id = <phone_number_id>
+whatsapp_recipient = <recipient_number>
+
+# Discord
+discord_webhook_url = <webhook_url>
+
+# Custom webhook
+webhook_url = <webhook_url>
+
+# Custom webhook authentication (optional)
+webhook_auth_header = Authorization: Bearer <token>
+
+# Custom webhook mTLS (optional, advanced)
+webhook_client_cert = /etc/pamsignal/webhook-client.crt
+webhook_client_key  = /etc/pamsignal/webhook-client.key
+webhook_ca_bundle   = /etc/pamsignal/webhook-ca.pem
+```
+
+## Phát hiện brute-force
+
+| Key | Mặc định | Khoảng giá trị | Mô tả |
+|-----|---------|-------|-------------|
+| `fail_threshold` | `5` | 1 - 10000 | Số lần thất bại trước khi kích hoạt cảnh báo |
+| `fail_window_sec` | `300` | 1 - 86400 | Cửa sổ thời gian (giây) để đếm số lần thất bại theo IP |
+| `max_tracked_ips` | `256` | 1 - 100000 | Số IP tối đa được theo dõi cùng lúc |
+| `alert_cooldown_sec` | `60` | 0 - 86400 | Số giây tối thiểu giữa các cảnh báo cho cùng một IP (0 = không có cooldown) |
+
+## Bộ lọc loại thông báo
+
+`enable_notification_type` cho phép chọn những loại sự kiện nào sẽ kích hoạt cảnh báo trên các kênh chat. Đây là danh sách phân cách bằng dấu phẩy. Mặc định — khi key bị bỏ qua hoặc khi `all` được chỉ định — là mọi loại sự kiện, giữ nguyên hành vi trước đó. Các token không hợp lệ là lỗi config cứng; giá trị rỗng và các phần tử danh sách rỗng đều bị từ chối.
+
+| Token | Kích hoạt cảnh báo chat khi… |
+|-------|---------------------------|
+| `login_success` | Phát hiện đăng nhập thành công (sshd, login) |
+| `login_failed` | Phát hiện đăng nhập thất bại (sshd, login; lỗi sudo/su vẫn chịu sự chặn lọc riêng theo từng sự kiện — xem bên dưới) |
+| `session_open` | Một PAM session mở ra (bao gồm cả các session nền của systemd như cron) |
+| `session_close` | Một PAM session đóng lại |
+| `brute_force` | Ngưỡng brute-force từ xa (theo IP) hoặc nội bộ (theo actor sudo/su) bị vượt qua |
+| `all` | Sentinel cho tất cả các loại ở trên (tương đương với việc bỏ qua key) |
+
+**Phạm vi áp dụng.** Bộ lọc này chỉ kiểm soát việc gửi cảnh báo qua chat (Telegram, Slack, Teams, WhatsApp, Discord, custom webhook). Nhật ký cục bộ qua `journalctl -t pamsignal` vẫn ghi lại mọi sự kiện bất kể cài đặt, nên log forensics luôn đầy đủ. Cơ chế chặn riêng theo từng sự kiện cho `LOGIN_FAILED` của sudo/su (chỉ cảnh báo brute-force tổng hợp mới được gửi) là độc lập và nằm bên dưới bộ lọc này.
+
+Ví dụ:
+
+```ini
+# Chỉ đăng nhập thành công và phát hiện brute-force
+enable_notification_type = login_success,brute_force
+
+# Chỉ brute-force
+enable_notification_type = brute_force
+
+# Tất cả (mặc định)
+enable_notification_type = all
+```
+
+## Các kênh cảnh báo
+
+Chỉ cấu hình những kênh bạn sử dụng. PAMSignal gửi cảnh báo đến tất cả các kênh đã có thông tin xác thực. Cảnh báo là best-effort — nếu một kênh bị lỗi, pamsignal ghi log cảnh báo và tiếp tục giám sát.
+
+Xem [Alerts](./alerts.md) để biết định dạng tin nhắn, hướng dẫn cài đặt và tham chiếu payload.
+
+| Key | Kênh | Mô tả |
+|-----|---------|-------------|
+| `telegram_bot_token` | Telegram | Bot token từ [@BotFather](https://t.me/BotFather) |
+| `telegram_chat_id` | Telegram | ID của chat, group hoặc channel |
+| `slack_webhook_url` | Slack | Incoming webhook URL |
+| `teams_webhook_url` | Teams | Incoming webhook URL |
+| `whatsapp_access_token` | WhatsApp | Meta Cloud API access token |
+| `whatsapp_phone_number_id` | WhatsApp | Phone Number ID từ dashboard |
+| `whatsapp_recipient` | WhatsApp | Số điện thoại người nhận có mã quốc gia (ví dụ: `84901234567`) |
+| `discord_webhook_url` | Discord | Webhook URL từ cài đặt channel |
+| `webhook_url` | Custom | URL endpoint của bạn (nhận JSON POST) |
+
+## Xác thực custom webhook
+
+Kênh `webhook_url` hỗ trợ hai cơ chế xác thực bổ sung tùy chọn — có thể dùng không cái nào, một trong hai, hoặc cả hai. Telegram, Slack, Teams, WhatsApp và Discord tự xác thực qua URL/token riêng của chúng và không bị ảnh hưởng.
+
+| Key | Chế độ | Mô tả |
+|-----|------|-------------|
+| `webhook_auth_header` | Header | Một HTTP header tùy ý gửi kèm theo mỗi POST. Dạng đầy đủ `Name: value` để hỗ trợ mọi scheme xác thực (Bearer, API key, Splunk HEC, Datadog, HMAC). Giá trị được đưa vào một curl `-K` config file backed bởi memfd, nên secret không bao giờ xuất hiện trong `argv` hay `/proc/<pid>/cmdline`. |
+| `webhook_client_cert` | mTLS | Đường dẫn đến client certificate mã hóa PEM. Phải được đặt cùng với `webhook_client_key`. |
+| `webhook_client_key` | mTLS | Đường dẫn đến private key PEM tương ứng. **Không được phép đọc bởi group hoặc other** — pamsignal sẽ từ chối khởi động nếu vi phạm. Khuyến nghị: `0640 root:pamsignal` (hoặc `0600 pamsignal:pamsignal` nếu chạy daemon dưới user đó). |
+| `webhook_ca_bundle` | mTLS | Đường dẫn tùy chọn đến CA bundle PEM. Chỉ cần khi CA của receiver không có trong system trust store (CA nội bộ, internal cert-manager). |
+
+**Các pattern thường dùng:**
+
+```ini
+# Chỉ Bearer — hầu hết các receiver (Wazuh, Splunk HEC, Datadog, custom Express receivers).
+webhook_url = https://siem.example.com/ingest/pamsignal
+webhook_auth_header = Authorization: Bearer <token>
+
+# Chỉ mTLS — môi trường đã có PKI; xác thực danh tính service ở tầng transport.
+webhook_url = https://siem.internal.example.com/ingest
+webhook_client_cert = /etc/pamsignal/webhook-client.crt
+webhook_client_key  = /etc/pamsignal/webhook-client.key
+
+# Kết hợp — SIEM gateway doanh nghiệp yêu cầu cả transport auth lẫn per-request authorization.
+webhook_url = https://siem.internal.example.com/ingest
+webhook_auth_header = Authorization: Bearer <jwt>
+webhook_client_cert = /etc/pamsignal/webhook-client.crt
+webhook_client_key  = /etc/pamsignal/webhook-client.key
+webhook_ca_bundle   = /etc/pamsignal/internal-ca.pem
+```
+
+*Bất kỳ pattern nào trong số này đều có thể kết hợp với `enable_notification_type` để thu hẹp loại sự kiện nào được gửi đến webhook — xem [Bộ lọc loại thông báo](#bộ-lọc-loại-thông-báo) ở trên để biết danh sách đầy đủ các token (`login_success`, `login_failed`, `session_open`, `session_close`, `brute_force`, `all`).*
+
+**Các kiểm tra xác thực được thực thi khi load config:**
+
+- Đặt bất kỳ key TLS nào trong ba key mà không có `webhook_url` là lỗi load config.
+- `webhook_client_cert` và `webhook_client_key` phải được đặt cùng nhau; thiếu một trong hai sẽ bị từ chối.
+- Tất cả đường dẫn cert/key/CA đều được mở với `O_NOFOLLOW` (symlink bị từ chối) và phải là file thường thuộc sở hữu của `root` hoặc daemon user.
+- Các chuỗi đường dẫn chứa ký tự điều khiển, `"` hoặc `\` đều bị từ chối để đảm bảo giá trị rõ ràng trong curl `-K` config.
+- `webhook_auth_header` phải ở dạng `Name: value`; các giá trị chứa CR, LF, `"` hoặc `\` đều bị từ chối (bảo vệ chống CRLF header injection / quote-escape).
+
+Khóa mã hóa (protected bằng passphrase) không được hỗ trợ — hãy quản lý bí mật của key thông qua quyền filesystem, `systemd-creds`, hoặc mô hình secret injection của cert manager.
+
+Xem [Alerts → Custom webhook (ECS JSON)](./alerts.md#custom-webhook-ecs-json) để biết payload truyền qua mạng, bảng các pattern receiver (Bearer / X-API-Key / Splunk / Datadog / Wazuh), và hướng dẫn triển khai mTLS phía operator.
+
+## CLI flags
+
+| Flag | Viết tắt | Mô tả |
+|------|-------|-------------|
+| `--foreground` | `-f` | Chạy ở chế độ foreground (không daemonize) |
+| `--config PATH` | `-c PATH` | Sử dụng file config ở đường dẫn tùy chỉnh |
+
+Đường dẫn tương đối sẽ được chuyển thành đường dẫn tuyệt đối trước khi daemonize.
+
+## Reload không cần restart
+
+```bash
+sudo systemctl reload pamsignal
+```
+
+Lệnh này gửi SIGHUP đến daemon. Nếu config mới hợp lệ, nó có hiệu lực ngay lập tức và bảng theo dõi brute-force sẽ được reset. Nếu config có lỗi, daemon giữ nguyên config hiện tại và ghi log cảnh báo.

--- a/docs/vi/deployment.md
+++ b/docs/vi/deployment.md
@@ -1,0 +1,228 @@
+# Deployment
+
+> 🌐 [English](../deployment.md) · **Tiếng Việt**
+
+## Cài đặt
+
+Con đường được khuyến nghị là dùng file `.deb` hoặc `.rpm` đã phát hành từ project repo (cùng các lệnh một dòng trong [README quick start](README.md#1-cài-đặt)). Các package này tạo system user `pamsignal`, đặt quyền file config thành `root:pamsignal 0640`, và kích hoạt systemd unit cho bạn — khi cài qua `apt` hoặc `dnf` bạn có thể bỏ qua thẳng đến [Cấu hình](#cấu-hình).
+
+Nếu build từ source, bạn tự thực hiện các bước đó; xem phần "Source build" bên dưới.
+
+### Debian / Ubuntu (apt)
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://anhtuank7c.github.io/pamsignal/key.asc \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/pamsignal.gpg
+echo "deb [signed-by=/etc/apt/keyrings/pamsignal.gpg] https://anhtuank7c.github.io/pamsignal stable main" \
+  | sudo tee /etc/apt/sources.list.d/pamsignal.list
+sudo apt update && sudo apt install pamsignal
+```
+
+`/etc/apt/keyrings` là vị trí tiêu chuẩn cho các APT signing key được cài bởi system administrator (theo `sources.list(5)`); dòng `install -d` là idempotent và an toàn để chạy lại trên các hệ thống đã có thư mục này.
+
+Package cài đặt `/usr/bin/pamsignal`, `/usr/lib/systemd/system/pamsignal.service`, `/etc/pamsignal/pamsignal.conf` và `/usr/share/man/man8/pamsignal.8.gz`. User `pamsignal` và membership trong group `systemd-journal` được tạo trong `postinst`. Tiếp tục tại [Cấu hình](#cấu-hình).
+
+### Fedora / RHEL / AlmaLinux / Rocky (dnf)
+
+```bash
+# Fedora / CentOS
+sudo dnf config-manager addrepo \
+  --from-repofile=https://anhtuank7c.github.io/pamsignal/rpm/fedora/pamsignal.repo
+
+# RHEL 9 / AlmaLinux 9 / Rocky Linux 9
+sudo dnf config-manager --add-repo \
+  https://anhtuank7c.github.io/pamsignal/rpm/el9/pamsignal.repo
+
+sudo dnf install pamsignal
+```
+
+Bố cục giống với deb (`/usr/bin`, `/usr/lib/systemd/system`, `/etc/pamsignal`, `/usr/share/man/man8/pamsignal.8.gz`). User và group `pamsignal` được tạo trong block `%pre` của spec. Tiếp tục tại [Cấu hình](#cấu-hình).
+
+### Source build (`meson install`)
+
+```bash
+# Build
+meson setup build
+meson compile -C build
+
+# Cài đặt binary, service file, example config và man page
+sudo meson install -C build
+```
+
+Với `--prefix=/usr/local` mặc định bạn sẽ có:
+
+- `/usr/local/bin/pamsignal` — binary (quy ước hiện đại của systemd: các daemon định hướng admin chia sẻ `/usr/bin` với mọi thứ khác, giống như `journalctl`, `systemctl`, `podman`, `containerd`)
+- `/usr/local/lib/systemd/system/pamsignal.service` — systemd unit (đường dẫn tìm kiếm vendor unit)
+- `/usr/local/etc/pamsignal/pamsignal.conf` — example config (từ `pamsignal.conf.example`)
+- `/usr/local/share/man/man8/pamsignal.8` — man page
+
+Để cài toàn hệ thống theo bố cục giống package (`/usr/bin`, `/usr/lib/systemd/system`, `/etc/pamsignal`), cấu hình lại với `meson setup build --prefix=/usr --sysconfdir=/etc`.
+
+Source build **không** tạo system user `pamsignal` hay khóa quyền file config — hãy tự thực hiện các bước đó trước khi khởi động service:
+
+```bash
+sudo useradd -r -s /usr/sbin/nologin pamsignal
+sudo usermod -aG systemd-journal pamsignal
+
+# Khóa example config để thông tin xác thực chỉ đọc được bởi
+# daemon (group=pamsignal) nhưng không public. Các script postinst
+# của deb/rpm thực hiện điều này tự động khi cài package.
+sudo chown root:pamsignal /usr/local/etc/pamsignal/pamsignal.conf
+sudo chmod 0640 /usr/local/etc/pamsignal/pamsignal.conf
+```
+
+## Cấu hình
+
+Chỉnh sửa file config. Đường dẫn tùy thuộc vào cách bạn đã cài đặt:
+
+- Cài package (deb/rpm) hoặc source build với `--prefix=/usr --sysconfdir=/etc`: `/etc/pamsignal/pamsignal.conf`
+- Source build với `--prefix=/usr/local` mặc định: `/usr/local/etc/pamsignal/pamsignal.conf`
+
+```bash
+sudo editor /etc/pamsignal/pamsignal.conf
+```
+
+Tất cả các giá trị đều tùy chọn — mặc định đã hợp lý. Để bật cảnh báo, thêm thông tin xác thực kênh của bạn (ví dụ: Telegram, Slack):
+
+```ini
+telegram_bot_token = <bot_token>
+telegram_chat_id = <chat_id>
+```
+
+Xem [Configuration](./configuration.md) để biết tất cả các tùy chọn.
+
+### Xác thực custom webhook
+
+Nếu bạn trỏ `webhook_url` đến SIEM hoặc receiver của riêng mình, hãy cấu hình xác thực với `webhook_auth_header` (Bearer token, API key, v.v.) hoặc — với môi trường đã có PKI — `webhook_client_cert` + `webhook_client_key` cho mTLS:
+
+```bash
+# Đặt client cert + key trong thư mục config của daemon.
+sudo install -d -o root -g pamsignal -m 0750 /etc/pamsignal
+sudo install -o root -g pamsignal -m 0644 webhook-client.crt /etc/pamsignal/
+sudo install -o root -g pamsignal -m 0640 webhook-client.key /etc/pamsignal/
+```
+
+Daemon sẽ từ chối khởi động nếu `webhook_client_key` có quyền đọc cho group hoặc other; mode `0640` với group `pamsignal` là bố cục chuẩn (khớp với chính `pamsignal.conf`). Nếu cert manager của bạn (cert-manager, certbot, `systemd-creds`) triển khai key ở nơi khác, hãy trỏ `webhook_client_key` đến đường dẫn đó — pamsignal mở file với `O_NOFOLLOW` và xác thực quyền sở hữu cùng mode khi mỗi lần load config. Xem [Configuration → Xác thực custom webhook](./configuration.md#xác-thực-custom-webhook) để biết tham chiếu đầy đủ.
+
+## Khởi động service
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now pamsignal
+```
+
+## Kiểm tra
+
+```bash
+# Kiểm tra trạng thái
+sudo systemctl status pamsignal
+
+# Xem log
+journalctl -u pamsignal -f
+
+# Chỉ xem các sự kiện pamsignal
+journalctl -t pamsignal -f
+```
+
+## Reload config
+
+Sau khi chỉnh sửa `/etc/pamsignal/pamsignal.conf`:
+
+```bash
+sudo systemctl reload pamsignal
+```
+
+Lệnh này gửi SIGHUP — không có downtime, không cần restart.
+
+## Dừng
+
+```bash
+sudo systemctl stop pamsignal
+```
+
+## Gỡ cài đặt
+
+Lệnh phù hợp phụ thuộc vào cách bạn đã cài đặt pamsignal. Nếu bạn dùng `.deb` hoặc `.rpm` đã phát hành (con đường trong README của project), package manager sẽ xử lý mọi thứ cho bạn. Hướng dẫn thủ công chỉ dành cho các cài đặt thực hiện từ source qua `meson install`.
+
+### Cài package (Debian / Ubuntu, qua `apt`)
+
+`dpkg` phân biệt hai giai đoạn gỡ cài đặt:
+
+```bash
+# Gỡ mềm: dừng service, xóa binary / unit / man page,
+# nhưng GIỮ LẠI /etc/pamsignal/pamsignal.conf để lần cài lại sau
+# vẫn có thông tin xác thực và cài đặt điều chỉnh của bạn.
+sudo apt remove pamsignal
+
+# Gỡ cứng: dừng service VÀ xóa /etc/pamsignal/. Dùng khi
+# bạn thực sự muốn loại bỏ hoàn toàn pamsignal khỏi host.
+sudo apt purge pamsignal
+```
+
+Các maintainer script đi kèm package (`debian/pamsignal.{prerm,postrm}`) xử lý `systemctl stop`, `systemctl disable` và `daemon-reload`. System user `pamsignal` **được cố ý giữ lại** qua cả `remove` và `purge` — nếu có bất kỳ file nào trên hệ thống được tạo với UID đó (artifact runtime, file sót lại bất ngờ) mà user bị xóa, file sẽ bị orphan với UID số mà kernel có thể sau này tái sử dụng cho một user khác. Chỉ xóa user thủ công sau khi bạn đã xác nhận không có gì trên hệ thống thuộc sở hữu của nó:
+
+```bash
+sudo find / -user pamsignal 2>/dev/null
+sudo userdel pamsignal     # chỉ khi lệnh find trên không trả về gì
+```
+
+### Cài package (Fedora / RHEL / AlmaLinux / Rocky, qua `dnf`)
+
+rpm chỉ có một lệnh gỡ cài đặt:
+
+```bash
+sudo dnf remove pamsignal
+```
+
+Không có tương đương với `apt purge` — `dnf remove` đã xóa mọi thứ package đặt trên đĩa. Một điểm tinh tế: nếu bạn đã chỉnh sửa `/etc/pamsignal/pamsignal.conf` sau khi cài đặt, `rpm` sẽ lưu bản sửa đổi của bạn dưới tên `/etc/pamsignal/pamsignal.conf.rpmsave` thay vì xóa nó (chỉ thị `%config(noreplace)` trong `pamsignal.spec`). Xóa file `.rpmsave` bằng tay nếu bạn không còn cần cấu hình cũ.
+
+Các block `%preun` / `%postun` trong spec xử lý vòng đời systemd. User `pamsignal` được giữ lại khi gỡ cài đặt vì lý do tương tự giải thích ở trên.
+
+### Source build (`meson install`)
+
+Nếu bạn đã chạy `sudo meson install -C build` thay vì cài package, không có cơ sở dữ liệu package manager nào theo dõi những gì đã được đặt ở đâu — bạn phải hoàn tác thủ công:
+
+```bash
+sudo systemctl stop pamsignal
+sudo systemctl disable pamsignal
+sudo rm /usr/local/bin/pamsignal
+sudo rm /usr/local/lib/systemd/system/pamsignal.service
+sudo rm -f /usr/local/share/man/man8/pamsignal.8
+sudo rm -rf /usr/local/etc/pamsignal
+# Chỉ thị ConfigurationDirectory=pamsignal của systemd tự động tạo
+# /etc/pamsignal/ khi unit khởi động lần đầu bất kể --prefix; với
+# dev install dùng --prefix=/usr/local thư mục này rỗng và
+# không được dùng nhưng vẫn bị để lại trừ khi xóa thủ công.
+sudo rm -rf /etc/pamsignal
+sudo userdel pamsignal
+sudo systemctl daemon-reload
+```
+
+`/run/pamsignal/` không cần dọn dẹp thủ công — `RuntimeDirectory=pamsignal` tự xóa nó khi service dừng.
+
+Nếu bạn đã cấu hình lại build với `--prefix=/usr --sysconfdir=/etc` để phản chiếu bố cục package, hãy thay `/usr/local/bin`, `/usr/local/lib/systemd/system`, `/usr/local/share/man/man8` và `/usr/local/etc/pamsignal` bằng các đối tương `/usr/...` và `/etc/...` tương ứng.
+
+## Hardening bảo mật
+
+File systemd service bao gồm các chỉ thị bảo mật sau:
+
+| Chỉ thị | Tác dụng |
+|-----------|--------|
+| `User=pamsignal` | Chạy với user không có quyền đặc biệt |
+| `NoNewPrivileges=yes` | Không thể nhận thêm quyền mới |
+| `ProtectSystem=strict` | Filesystem ở chế độ chỉ đọc |
+| `ProtectHome=yes` | Ẩn các thư mục home |
+| `PrivateTmp=yes` | Mount `/tmp` riêng tư |
+| `MemoryDenyWriteExecute=yes` | Không có vùng nhớ vừa ghi được vừa thực thi được (W^X) |
+| `ProtectKernelTunables=yes` | `/proc/sys` và `/sys` ở chế độ chỉ đọc |
+| `ProtectKernelModules=yes` | Không thể nạp kernel module |
+| `ProtectKernelLogs=yes` | Không thể đọc kernel log buffer |
+| `RestrictNamespaces=yes` | Không thể tạo namespace |
+| `RestrictSUIDSGID=yes` | Không thể đặt bit SUID/SGID |
+| `PrivateDevices=yes` | Không có quyền truy cập vào thiết bị vật lý |
+| `LockPersonality=yes` | Không thể thay đổi execution domain |
+| `CapabilityBoundingSet=` | Tất cả capability bị bỏ |
+| `SystemCallFilter=@system-service` | Chỉ cho phép các syscall thuộc system-service |
+| `ConfigurationDirectory=pamsignal` | Tạo `/etc/pamsignal/` |
+| `RuntimeDirectory=pamsignal` | Tạo `/run/pamsignal/` |

--- a/docs/vi/development.md
+++ b/docs/vi/development.md
@@ -1,0 +1,169 @@
+# Development Guide
+
+> 🌐 [English](../development.md) · **Tiếng Việt**
+
+## Điều kiện tiên quyết
+
+```bash
+sudo apt install libsystemd-dev pkg-config build-essential meson ninja-build \
+    libcmocka-dev clang-format clang-tidy
+```
+
+## Build
+
+```bash
+# Lần đầu: cấu hình thư mục build
+meson setup build
+
+# Biên dịch
+meson compile -C build
+```
+
+## Clean
+
+```bash
+rm -rf build
+meson setup build
+```
+
+## Unit Test
+
+Unit test dùng [CMocka](https://cmocka.org/) và được tích hợp với hệ thống build Meson.
+
+```bash
+# Chạy tất cả test
+meson test -C build -v
+
+# Chạy một test suite đơn lẻ
+meson test -C build test_utils
+meson test -C build test_config
+```
+
+### Các test suite
+
+| Suite | File | Số test | Bao phủ |
+|-------|------|-------|--------|
+| `test_utils` | `tests/test_utils.c` | 30 | PAM message parsing, field extraction, IP validation, sanitization, enum-to-string, định dạng timestamp ISO-8601, truncation marker |
+| `test_config` | `tests/test_config.c` | 32 | Config default, file loading, whitespace trimming, boundary value, error handling, partial config, validator rejection (hình dạng token, URL scheme/charset, WhatsApp id), từ chối file-permission (group/world-writable, symlink) |
+| `test_notify` | `tests/test_notify.c` | 3 | Smoke test public dispatch API: no-channels no-op, cooldown handling khi gọi lặp lại |
+| `test_journal_watch` | `tests/test_journal_watch.c` | 13 | Brute-force tracker: validation `ps_fail_table_init`, hành vi bộ đếm single/multi-IP, window expiration, threshold breach, cooldown suppression và release theo IP, eviction-by-oldest, bỏ qua IP rỗng |
+
+### Viết test
+
+- Mỗi hàm mới hoặc hành vi thay đổi phải có các test tương ứng.
+- Test đặt trong file tương ứng: `src/foo.c` → `tests/test_foo.c`.
+- Đăng ký test executable mới trong `meson.build` dưới section `# --- Tests ---`.
+- Dùng CMocka assertion (`assert_int_equal`, `assert_string_equal`, `assert_null`, v.v.).
+
+## Fuzzing
+
+`ps_parse_message` là parser cho đầu vào từ đối thủ (thông báo system journal), nên nó có libFuzzer harness trong `tests/fuzz_parse_message.c` được gate bởi meson option `fuzz`. Build yêu cầu clang vì `-fsanitize=fuzzer` chỉ có trên clang; ASan và UBSan được bật cùng.
+
+```bash
+# Cấu hình một build directory riêng với fuzzing được bật
+CC=clang-21 meson setup -Dfuzz=enabled build-fuzz
+
+# Build harness
+meson compile -C build-fuzz fuzz_parse_message
+
+# Chạy trong 60 giây. Đối số vị trí đầu tiên là corpus làm việc của libFuzzer
+# (có thể ghi — các phát hiện được lưu ở đây); đối số thứ hai là seed
+# corpus read-only. build-fuzz/ được gitignore nên các phát hiện không vào repo.
+mkdir -p build-fuzz/corpus
+./build-fuzz/fuzz_parse_message build-fuzz/corpus \
+    tests/fuzz/parse_message_corpus -max_total_time=60
+```
+
+Crash được ghi vào `crash-<sha1>` trong thư mục hiện tại. Dùng file crash để regression: `./build-fuzz/fuzz_parse_message crash-<sha1>` tái hiện đầu vào lỗi. Nếu một mục corpus được khám phá thực thi một code path mới thực sự đáng giữ lại, hãy copy nó vào `tests/fuzz/parse_message_corpus/` với tên mô tả.
+
+Option `fuzz` mặc định là `disabled`, nên quy trình `meson setup build` + gcc thông thường không bị ảnh hưởng.
+
+## Định dạng và Linting
+
+```bash
+# Tự động định dạng tất cả file source
+clang-format -i src/*.c include/*.h tests/*.c
+
+# Kiểm tra mà không sửa đổi (thân thiện CI)
+clang-format --dry-run --Werror src/*.c include/*.h tests/*.c
+
+# Phân tích tĩnh
+clang-tidy src/*.c -- $(pkg-config --cflags libsystemd) -I include
+```
+
+File cấu hình: `.clang-format`, `.clang-tidy` trong thư mục gốc dự án.
+
+## Thiết lập môi trường test
+
+PAMSignal chạy dưới dạng người dùng không có đặc quyền chuyên dụng với quyền đọc journal (không phải root).
+
+```bash
+# Tạo system user cho pamsignal (không có login shell, không có home directory)
+sudo useradd -r -s /usr/sbin/nologin pamsignal
+
+# Cấp quyền đọc systemd journal
+sudo usermod -aG systemd-journal pamsignal
+```
+
+Bạn cũng cần SSH có sẵn cục bộ để tạo các sự kiện đăng nhập thực:
+
+```bash
+sudo apt install openssh-server
+sudo systemctl enable --now ssh
+```
+
+## Chạy (thủ công)
+
+```bash
+# Chế độ foreground (Ctrl+C để dừng)
+sudo -u pamsignal ./build/pamsignal --foreground
+
+# Hoặc dưới dạng background daemon
+sudo -u pamsignal ./build/pamsignal
+
+# Với config file tùy chỉnh
+sudo -u pamsignal ./build/pamsignal -f -c ./pamsignal.conf.example
+```
+
+## Dừng
+
+```bash
+# Nếu đang chạy thủ công dưới dạng background daemon
+sudo kill $(pgrep pamsignal)
+```
+
+## Kiểm thử end-to-end
+
+Khởi động pamsignal và mở terminal thứ hai để xem đầu ra của nó:
+
+```bash
+journalctl -t pamsignal -f
+```
+
+Rồi trong terminal thứ ba, kích hoạt các sự kiện:
+
+```bash
+# 1. Đăng nhập SSH thành công (kỳ vọng: LOGIN_SUCCESS + SESSION_OPEN)
+ssh localhost
+# gõ 'exit' (kỳ vọng: SESSION_CLOSE)
+
+# 2. Đăng nhập SSH thất bại (kỳ vọng: LOGIN_FAILED)
+ssh nonexistent@localhost
+
+# 3. Phát hiện brute-force (kỳ vọng: BRUTE_FORCE_DETECTED sau 5 lần thất bại)
+for i in $(seq 1 5); do ssh nonexistent@localhost; done
+
+# 4. Sudo session (kỳ vọng: SESSION_OPEN cho sudo)
+sudo ls
+
+# 5. Tắt graceful (kỳ vọng: "shutting down" trong journal)
+sudo kill $(pgrep pamsignal)
+# hoặc Ctrl+C nếu đang chạy ở foreground
+```
+
+## CLI flags
+
+| Flag | Viết tắt | Mô tả |
+|------|-------|-------------|
+| `--foreground` | `-f` | Chạy ở foreground (không daemonize) |
+| `--config PATH` | `-c PATH` | Dùng config file path thay thế |

--- a/docs/vi/distros.md
+++ b/docs/vi/distros.md
@@ -1,0 +1,100 @@
+# Supported Linux Distributions
+
+> 🌐 [English](../distros.md) · **Tiếng Việt**
+
+PAMSignal được thiết kế cho Linux hiện đại có systemd native. Các bản phát hành cũ hơn có thể không có các hàm libc mà daemon gọi (`memfd_create`, dùng để cách ly thông tin xác thực trong đường dẫn alert dispatch), không có các chỉ thị systemd unit mà phần hardening của project dựa vào (`ProcSubset=pid`, `ProtectProc=invisible`, `ProtectClock=`, `ProtectHostname=`, `RestrictNamespaces=`, bộ syscall `@system-service`), hoặc không có phiên bản debhelper đủ mới để build package. Tài liệu này là tham chiếu chính thống cho câu hỏi "liệu pamsignal có chạy được trên host của tôi không?" và được tham chiếu từ [`SECURITY.md`](../../SECURITY.md) và chỉ mục tài liệu [README](README.md).
+
+Các tier hỗ trợ dưới đây có ý nghĩa và cam kết khác nhau:
+
+- **Tier 1 — Được CI kiểm thử**. Mỗi release được build và kiểm thử end-to-end trên các distro này. Các file `.deb` / `.rpm` được phát hành trên apt+dnf repo gh-pages là các artifact đã qua các bài kiểm thử này. Một regression ở Tier 1 sẽ làm thất bại release workflow và được xử lý như release blocker.
+- **Tier 2 — Dự kiến hoạt động**. Codebase + dependencies nên hỗ trợ các distro này, nhưng không có bài kiểm thử tự động nào liên tục xác minh. Có thể có những lưu ý cụ thể (systemd cũ thiếu một số chỉ thị hardening, điểm `systemd-analyze security` live cao hơn đôi chút). Các báo cáo lỗi trên Tier 2 được chào đón và xử lý với độ ưu tiên bình thường.
+- **Tier 3 — Không được hỗ trợ**. Pamsignal sẽ không compile, không cài đặt được, hoặc không áp dụng đủ hardening để các tuyên bố bảo mật trong [`docs/threat-model.md`](./threat-model.md) còn giá trị. Các báo cáo lỗi trên Tier 3 sẽ bị đóng với liên kết trỏ về tài liệu này.
+
+Một thực tế quan trọng bạn cần ghi nhớ: **file `.deb` được phát hành được build một lần mỗi release trên CI runner Tier 1**, hiện tại có nghĩa là dependency runtime `libsystemd0` của package được ghim theo phiên bản libsystemd của runner (Ubuntu 24.04 kèm libsystemd0 255). Trên các Ubuntu và Debian cũ hơn, `apt install pamsignal` từ repo gh-pages sẽ từ chối với thông báo "unmet dependencies" ngay cả khi chính codebase có thể compile tốt. Các phương pháp cài đặt Tier 2 được ghi lại theo từng dòng.
+
+## Tier 1 — Được CI kiểm thử
+
+Release workflow gồm các job `test-deb` và `test-rpm` để build package, cài đặt dưới systemd trong container/VM sạch, cấu hình daemon với mock HTTPS webhook, thực hiện các sự kiện xác thực sshd thực, xác minh cấu trúc ECS payload, kiểm tra SIGHUP reload, rồi `apt purge` / `dnf remove` để xác nhận việc dọn dẹp. Pass = ship.
+
+| Distro | Phiên bản | systemd | glibc | OpenSSH | sshd binary | Điểm bảo mật live | Phương pháp cài đặt |
+|---|---|---|---|---|---|---|---|
+| **Ubuntu** | 24.04 LTS (Noble) | 255 | 2.39 | 9.6 | `sshd` | 1.3 (OK) | `apt install pamsignal` từ repo gh-pages |
+| **Fedora** | 44+ (`fedora:latest`) | 256+ | 2.40+ | 9.9+ | `sshd-session` | 1.3 (OK) | `dnf install pamsignal` từ repo gh-pages |
+| **AlmaLinux** / **Rocky Linux** | 9 | 252 | 2.34 | 8.7 | `sshd` | 1.3 (OK) | `dnf install pamsignal` từ repo gh-pages |
+
+Job `test-deb` thực hiện toàn bộ luồng E2E (`Type=notify` activation, brute-force sshd, SIGHUP reload, ECS payload). Các job `test-rpm` thực hiện cài đặt + gỡ cài đặt + xác minh bố cục file nhưng không thực hiện luồng daemon-dưới-systemd vì bài kiểm thử rpm chạy trong Docker container không có systemd PID 1.
+
+## Tier 2 — Dự kiến hoạt động, không được kiểm thử chủ động
+
+| Distro | Phiên bản | systemd | OpenSSH | Kết quả | Lưu ý |
+|---|---|---|---|---|---|
+| **Ubuntu** | 22.04 LTS (Jammy) | 249 | 8.9 | ✅ Compile + chạy | Không có `apt install pamsignal` từ repo gh-pages (dependency libsystemd ghim theo phiên bản 24.04). Build từ source qua `dpkg-buildpackage` trên host 22.04, hoặc chờ có per-distroseries pocket. |
+| **Ubuntu** | 20.04 LTS (Focal) | 245 | 8.2p1 | ✅ Compile + chạy; **được CI kiểm thử liên tục**; Focal `.deb` per-release được đính kèm vào GitHub release | ESM-only từ 2025-04-30 — chỉ Ubuntu Pro subscriber mới nhận cập nhật bảo mật cấp host. Không có apt pocket gh-pages (cơ sở hạ tầng per-distroseries repo chỉ hiệu quả trên ~30+ host); tải `pamsignal_*_focal_amd64.deb` trực tiếp từ [trang GitHub release](https://github.com/anhtuank7c/pamsignal/releases) và cài bằng `apt install ./<file>.deb`. Hai chỉ thị systemd (`ProtectProc=invisible`, `ProcSubset=pid`, cả hai thêm vào systemd v247) được ghi log và bỏ qua khi load unit — systemd tương thích ngược, daemon vẫn chạy; điểm bảo mật live cao hơn ~1-2 điểm so với 22.04+ nhưng vẫn trong ngưỡng "OK". Lên kế hoạch migration sang 22.04 LTS (Standard Support đến tháng 4/2027) trước tháng 4/2030 khi Focal hết ESM. |
+| **Ubuntu** | 26.04 (Resolute) | 259 | 9.10p2 | ✅ Compile + chạy (đã xác nhận bởi `tests/scenario.sh` ngày 2026-05-03; chưa có trong CI matrix) | Cùng lưu ý về package availability như 22.04 cho đến khi repo gh-pages có `resolute` pocket. |
+| **Debian** | 12 (Bookworm) | 252 | 9.2p1 | ✅ Compile + chạy | Cùng lưu ý về package availability. Build từ source. |
+| **Debian** | 13 (Trixie, dự kiến GA giữa 2026) | 257+ | 9.7+ | ✅ Compile + chạy | Cùng lưu ý về package availability. Có thể lên Tier 1 khi Trixie LTS ra mắt. |
+| **RHEL** | 9 | 252 | 8.7 | ✅ Cùng binary với AlmaLinux 9 | rpm AlmaLinux 9 Tier 1 nên cài được trên RHEL 9 vì chúng tương thích ABI ở cấp libc + libsystemd. |
+| **Fedora** | N-1 (43 tại thời điểm viết) | 254 | 9.6 | ✅ Compile + chạy | rpm Fedora Tier 1 nhắm vào `fedora:latest`; Fedora cũ hơn có thể hoặc không thỏa mãn các dependency string của nó. |
+
+Với tất cả các dòng Tier 2, trình phân tích cú pháp, brute-force tracker và alert dispatch của pamsignal hoạt động giống hệt Tier 1 — sự khác biệt là ma sát về upgrade path (per-distroseries package pocket), không phải hành vi runtime. Điểm `systemd-analyze security` live trên Ubuntu 22.04 / Debian 12 có thể cao hơn 1–2 điểm so với baseline CI vì các phiên bản systemd mới hơn tính trọng số chỉ thị hơi khác nhau, nhưng mọi chỉ thị trong unit đều được tuân thủ.
+
+**Ubuntu 20.04 (Focal) là trường hợp ngoại lệ trong Tier 2.** Nó được kiểm thử liên tục trong CI (các job `build-deb-focal` và `test-deb-focal` trong `.github/workflows/release-packages.yml` build và smoke-test một `.deb` nhắm vào Focal với container `ubuntu:20.04` mỗi release), và file `pamsignal_*_focal_amd64.deb` kết quả được đính kèm vào mỗi GitHub release. Operator cài bằng cách tải xuống trực tiếp thay vì dùng apt repo. Cách xử lý này dành riêng cho Focal vì phép tính vòng đời ESM — duy trì một build artifact release được kiểm thử chủ động thì rẻ, trong khi chạy một apt pocket đầy đủ cho một distro đã đóng băng, ESM-only thì không.
+
+## Tier 3 — Không được hỗ trợ
+
+| Distro | Phiên bản | systemd | glibc | Nguyên nhân không hỗ trợ |
+|---|---|---|---|---|
+| **Ubuntu** | 18.04 LTS (Bionic) | 237 | 2.27 | Nhiều chỉ thị sandbox bị thiếu (`ProtectProc=`, `ProcSubset=`, `ProtectClock=`, `ProtectHostname=`); điểm bảo mật live ~30+ |
+| **Ubuntu** | 16.04 LTS (Xenial) | 229 | 2.23 | **Không compile được** — `memfd_create()` không có trong glibc 2.23; thông tin xác thực alert sẽ phải fallback sang argv exposure, mâu thuẫn trực tiếp với biện pháp giảm thiểu trong threat model (attack #3 trong `docs/threat-model.md`) |
+| **Debian** | 11 (Bullseye) | 247 | 2.31 | Sandbox posture tương đương Ubuntu 20.04 (thiếu `ProtectProc`/`ProcSubset`) — nhưng Bullseye hiện không có trong CI matrix và không có Bullseye-targeted `.deb` nào được phát hành, nên chúng tôi không đưa ra claim hỗ trợ. Nếu bạn muốn chạy pamsignal trên Bullseye, build từ source qua `dpkg-buildpackage` trên host Bullseye — có thể hoạt động, nhưng bạn tự chịu trách nhiệm với regression. |
+| **Debian** | ≤10 | ≤241 | ≤2.28 | Cùng vấn đề với các Ubuntu release cũ hơn |
+| **CentOS / RHEL** | 7 (EOL 2024-06-30) | 219 | 2.17 | **Không compile được** — `memfd_create()` không có trong glibc 2.17 và kernel stock 3.10 thiếu syscall nền tảng (cần Linux 3.17+). Thông tin xác thực alert sẽ phải fallback sang argv exposure, mâu thuẫn với biện pháp giảm thiểu trong threat model (attack #3 trong `docs/threat-model.md`). systemd 219 cũng bỏ qua khoảng một nửa số chỉ thị hardening mà unit dựa vào. Xem [Tại sao CentOS / RHEL 7 không thể hỗ trợ được](#tại-sao-centos--rhel-7-không-thể-hỗ-trợ-được) bên dưới để biết migration path. |
+| **CentOS / RHEL** | 8 (EOL 2021/2024) | 239 | 2.28 | Tương đương Ubuntu 18.04 — sandbox posture quá xa so với tuyên bố trong threat model |
+| **Bất cứ thứ gì cũ hơn** | — | — | — | Tổ hợp glibc + systemd + OpenSSH mà hardening của pamsignal dựa vào không tồn tại. |
+
+Các ngưỡng cắt này được nêu rõ ràng vì threat model đưa ra các tuyên bố cụ thể (compiler hardening, chỉ thị sandbox, `_EXE` allowlist matching so với đường dẫn binary thực trên đĩa) phụ thuộc vào các phiên bản này. Một cài đặt pamsignal trên Tier 3 có thể *chạy* trong nhiều trường hợp, nhưng sẽ chạy với isolation posture yếu hơn đáng kể so với những gì chính sách bảo mật quảng cáo — các operator triển khai nó sẽ đưa ra quyết định dựa trên những đảm bảo mà host thực sự không cung cấp.
+
+## Tại sao CentOS / RHEL 7 không thể hỗ trợ được
+
+Các operator với đội CentOS 7 đôi khi hỏi liệu ngưỡng cắt có thể được nới lỏng không. Câu trả lời là không, vì ba lý do độc lập:
+
+1. **Không có syscall `memfd_create()` trong kernel.** Linux kernel đã thêm `memfd_create` trong 3.17 (tháng 10/2014). RHEL 7 / CentOS 7 stock kèm kernel 3.10 với vendor backport — `memfd_create` *không* nằm trong số các syscall được backport. Xác nhận trên host của bạn bằng `grep memfd_create /proc/kallsyms` (không có kết quả nghĩa là không có). pamsignal gọi nó tại [`../../src/notify.c:113`](../../src/notify.c) để build config file cho curl child trong một anonymous in-memory descriptor; tên descriptor `pamsignal-curl` chứa webhook URL, auth header và TLS-path config để `argv` của curl child không tiết lộ chúng trong `/proc/<pid>/cmdline` (có thể xác minh với `ps auxf` khi có active alert). Không có syscall đó, các chỗ duy nhất còn lại để đặt thông tin xác thực là argv (hiện thị cho mọi local user) hoặc tempfile (hiện thị cho bất kỳ ai có quyền đọc `/tmp` vào đúng lúc) — cả hai đều là mục tiêu trong [`../../docs/threat-model.md`](./threat-model.md) attack #3. Threat model sẽ phải bị hạ cấp để claim hỗ trợ CentOS 7, điều mà chúng tôi sẽ không làm.
+
+2. **Không có glibc wrapper cho `memfd_create()`.** Ngay cả khi một kernel được backport có syscall này, glibc của RHEL 7 là 2.17 — wrapper được đưa vào glibc 2.27 (2018). Daemon gọi `memfd_create("pamsignal-curl", MFD_CLOEXEC)` như một hàm libc, không phải `syscall(SYS_memfd_create, ...)`. Chuyển sang dạng raw syscall là có thể, nhưng không giúp mở khóa CentOS 7 — xem điểm 1.
+
+3. **EOL vào 2024-06-30.** CentOS 7 đã đến end-of-life vào ngày 30 tháng 6 năm 2024 — không còn cập nhật bảo mật upstream. Chạy daemon *giám sát bảo mật* trên một host không còn nhận cập nhật bảo mật là sự đảo ngược thứ tự ưu tiên: mức độ phơi nhiễm của host bây giờ lớn hơn những gì daemon phát hiện được, và bất kỳ CVE nào chưa được vá trong kernel, openssh, sudo hoặc systemd sẽ bị khai thác trước khi pamsignal có thể quan sát được một failed-auth event từ cuộc tấn công.
+
+### Migration path cho các host CentOS 7
+
+Ba lựa chọn thực tế, theo thứ tự gián đoạn tăng dần:
+
+| Lựa chọn | Trông như thế nào | Khi nào nên dùng |
+|---|---|---|
+| **Migration in-place sang AlmaLinux 9 / Rocky Linux 9 / RHEL 9** | Chạy vendor migration script (`almalinux-deploy.sh` từ AlmaLinux, `migrate2rocky.sh` từ Rocky, `convert2rhel` từ Red Hat). Cả ba đều là Tier 1 / Tier 2 cho pamsignal, glibc 2.34, systemd 252, kernel 5.14 với cửa sổ hỗ trợ 10 năm. `/etc/sudoers`, sshd config và hầu hết app stack hiện có đều được chuyển tiếp không thay đổi. | Host là production server tồn tại lâu dài mà bạn muốn tiếp tục vận hành. Đây là con đường được khuyến nghị. |
+| **Container deployment trên host CentOS 7 hiện có** | Chạy pamsignal trong container `podman run` (hoặc docker) dựa trên `almalinux:9` hoặc `ubuntu:24.04`. Container mang theo glibc mới hơn của riêng nó, nên ràng buộc ở cấp libc được giải quyết. **Điều kiện tiên quyết bắt buộc**: kernel host phải ≥ 3.17 — `uname -r` phải báo cáo một backport mới hơn stock 3.10 (một số host CentOS 7 chạy `kernel-lt` 5.4 hoặc `kernel-ml` 6.x của elrepo, hoạt động được; `3.10.0-1160.x.x.el7` gốc thì không). Container cũng cần quyền đọc `/var/log/journal` từ host (journal là thứ pamsignal quan sát), điều này khó về mặt vận hành khi journald của host là nguồn dữ liệu thực. | Host không thể migrate (hợp đồng hỗ trợ ứng dụng vendor, ràng buộc quy định, v.v.) và kernel của nó đã được cập nhật lên backport gần đây. |
+| **Công cụ khác** | `auditd` đã có trên mọi host RHEL; kết hợp với `rsyslog`/`journald` forwarding đến SIEM (ví dụ: Wazuh, Splunk, Loki) và viết các correlation rule phát hiện brute-force phía SIEM. Đây là những gì hầu hết deployment CentOS 7 doanh nghiệp đã làm. | Host sẽ được ngừng hoạt động trong vòng 12 tháng tới và không đáng để migration, nhưng bạn vẫn muốn coverage phát hiện trong thời gian đó. |
+
+Nếu lựa chọn là phương án 1, việc migration nhẹ nhàng về mặt vận hành: các script AlmaLinux/Rocky hoán đổi package in-place mà không cần reboot cho phần lớn quá trình chuyển đổi (một lần reboot cuối nạp kernel mới). `dnf install pamsignal` Tier 1 của pamsignal hoạt động ngay lập tức trên host sau migration.
+
+## Kiến trúc
+
+CI kiểm thử **x86_64** mà thôi. Codebase là architecture-neutral (không có inline asm, không có architecture-specific intrinsics), các compiler hardening flag bao gồm `-fcf-protection=full` chỉ khi được hỗ trợ, và chỉ thị systemd `SystemCallArchitectures=native` tự động thích ứng. **arm64 / aarch64** do đó là Tier 2 theo mặc định — dự kiến hoạt động, không được kiểm thử chủ động. Các báo cáo lỗi trên aarch64 được chào đón.
+
+## Thêm distro vào Tier 1
+
+Một dòng được chuyển từ Tier 2 lên Tier 1 khi:
+
+1. CI matrix của release workflow gồm `test-deb` (hoặc `test-rpm`) có thêm entry strategy cho distro mục tiêu.
+2. Bài kiểm thử end-to-end pass trên một CI run mới cho target đó.
+3. Repo apt/dnf gh-pages được phát hành có thêm per-distroseries pocket để user có thể `apt install pamsignal` / `dnf install pamsignal` với package build trên base phù hợp.
+4. Một regression trên target đó làm thất bại release workflow.
+
+Tier 1 hiện tại được chọn theo những gì đã chạy trong CI. Mở rộng sang Ubuntu 22.04 + Ubuntu 26.04 + Debian 12 nằm trong roadmap; xem comment `# TODO: Tier 1 matrix expansion` gần job `test-deb` trong [`.github/workflows/release-packages.yml`](../../.github/workflows/release-packages.yml).
+
+## Những gì tài liệu này không đề cập
+
+- **Container runtime** (Docker, Podman, Kubernetes pod). PAMSignal là daemon đọc journald và phụ thuộc vào systemd thực sự. Chạy trong container không chia sẻ journal của host không được hỗ trợ theo thiết kế — threat model giả định daemon và các sự kiện nó đọc ở trên cùng kernel boundary.
+- **Các distro musl-based** (Alpine Linux, Void). PAMSignal link với các hàm đặc thù glibc (wrapper `memfd_create()`, `clearenv()`, fallback syscall `close_range()`). musl libc của Alpine có thể hoặc không cung cấp signature tương thích; hiện chưa được kiểm thử.
+- **Các BSD.** PAMSignal gọi trực tiếp `sd_journal_*`. Không có journald trên FreeBSD/OpenBSD/NetBSD; project sẽ cần một event source hoàn toàn khác. Ngoài phạm vi.
+
+Để có security posture tốt, hãy chạy pamsignal trên distro Tier 1.

--- a/docs/vi/examples/bruno-collection.md
+++ b/docs/vi/examples/bruno-collection.md
@@ -1,0 +1,178 @@
+# PAMSignal Webhook Bruno Collection
+
+> 🌐 [English](../../../examples/bruno-collection/README.md) · **Tiếng Việt**
+
+Các request [Bruno](https://www.usebruno.com/) sẵn dùng để kiểm thử bất kỳ webhook receiver PAMSignal nào — [ví dụ Node.js](nodejs-webhook.md), [ví dụ Python](python-webhook.md), hoặc bất kỳ triển khai nào khác theo cùng contract `POST /webhook/pamsignal`.
+
+Đã kiểm thử với **Bruno ≥ 3.3.0**.
+
+## Mục lục
+
+- [Bắt đầu nhanh](#bắt-đầu-nhanh) — nhận 200 OK đầu tiên trong năm bước
+- [Environments](#environments) — HTTP so với mTLS
+- [Gửi request đầu tiên](#gửi-request-đầu-tiên) — hướng dẫn giao diện
+- [Kiểm thử khả năng phòng thủ của receiver](#kiểm-thử-khả-năng-phòng-thủ-của-receiver) — cố tình kích hoạt 401 / 415 / 413 / 400
+- [Thiết lập mTLS](#thiết-lập-mtls) — quy trình client cert + CA tự ký
+- [Tùy chỉnh collection](#tùy-chỉnh-collection) — chỉnh sửa payload, thêm request, ghi đè từng request
+- [Xử lý sự cố](#xử-lý-sự-cố)
+
+## Bắt đầu nhanh
+
+1. Cài đặt [Bruno](https://www.usebruno.com/).
+2. Click **Open Collection** (không phải *Import Collection* — đường dẫn đó dùng cho Postman/OpenAPI JSON và sẽ thất bại với lỗi *"Unsupported collection format"*). Chọn thư mục `examples/bruno-collection`.
+3. Khởi động một trong các receiver mẫu trong terminal khác:
+   ```bash
+   # Python
+   cd ../python-webhook && uv run python src/server.py
+   # or Node.js
+   cd ../nodejs-webhook && pnpm run dev
+   ```
+4. Trong Bruno, chọn environment **Local** từ dropdown góc trên bên phải và click **biểu tượng mắt** để chỉnh sửa. Đặt `WEBHOOK_SECRET` thành giá trị bạn đã đặt trong `.env` của receiver.
+5. Mở request **Login Success** và click **Send**. Bạn sẽ thấy `200 OK` với `{"status":"success","message":"Event received"}`.
+
+Nếu bạn nhận được kết quả đó, collection đã được kết nối đúng. Phần còn lại của README này giải thích cách kiểm thử receiver kỹ lưỡng hơn.
+
+## Environments
+
+| Environment | URL | Dùng khi |
+|---|---|---|
+| **Local** | `http://localhost:3000/webhook/pamsignal` | Receiver đang chạy trên plain HTTP |
+| **Local-mTLS** | `https://localhost:3000/webhook/pamsignal` | Receiver có `TLS_REQUIRE_CLIENT_CERT=true` (xem [thiết lập mTLS](#thiết-lập-mtls)) |
+
+Cả hai đều dùng chung hai biến — `WEBHOOK_URL` và `WEBHOOK_SECRET` — mà mọi request đều tham chiếu qua `{{...}}`. Chuyển đổi environment chỉ cần một click vào dropdown; không cần chỉnh sửa request.
+
+## Gửi request đầu tiên
+
+1. Mở **Login Success** trong sidebar. Bạn sẽ thấy:
+   - Panel **URL**: `{{WEBHOOK_URL}}` — được nội suy lúc gửi từ environment đang hoạt động.
+   - Tab **Auth**: Bearer scheme, token `{{WEBHOOK_SECRET}}`.
+   - Tab **Body**: một tài liệu JSON có dạng ECS tổng hợp mô tả một event `login_success`.
+2. Click **Send**.
+3. Panel **Response** hiển thị:
+   - **Status**: `200 OK`
+   - **Body**: `{"status":"success","message":"Event received"}`
+   - **Headers**: `Content-Type: application/json`
+   - **Timeline**: thời gian round-trip, kích thước request/response
+4. Chuyển sang terminal của receiver — bạn sẽ thấy dòng log tương ứng:
+   ```
+   ✅ [LOGIN_SUCCESS] User 'admin' logged in via 10.0.0.1 on server-01 (PID: 1234)
+   ```
+
+Hai request cần sẵn còn lại (`Login Failure`, `Brute Force Detected`) hoạt động tương tự với các dạng payload khác nhau và tạo ra các tiền tố log khác nhau ở phía receiver.
+
+## Kiểm thử khả năng phòng thủ của receiver
+
+Receiver triển khai nhiều kiểm tra phòng thủ (xác thực, giới hạn kích thước body, Content-Type, hình dạng payload). Bạn có thể xác minh từng cái bằng cách cố tình phá một request và quan sát mã response. Mỗi hàng là một bài kiểm tra 30 giây:
+
+| Phòng thủ | Cách phá request | Response mong đợi |
+|---|---|---|
+| **Bearer auth** | Trong env, xóa `WEBHOOK_SECRET` (hoặc mở request → tab **Auth** → tạm thời đổi token). Gửi. | `401 {"error":"Unauthorized: Invalid or missing token"}` |
+| **Bearer auth (sai scheme)** | Tab Auth → chuyển từ *Bearer* sang *Basic*. Gửi. | `401` |
+| **Content-Type** | Tab **Body** → chuyển loại từ *JSON* sang *Text*. Giữ nguyên nội dung body. Gửi. | `415 {"error":"Unsupported Media Type: expected application/json"}` |
+| **Giới hạn kích thước body (64 KB)** | Tab Body → trong JSON, thêm một trường chuỗi dài, ví dụ: `"pad": "AAA…"` lặp lại khoảng 70 KB. Gửi. | `413 Payload Too Large` |
+| **Hình dạng payload** | Tab Body → xóa block `"event"` hoặc `"pamsignal"` khỏi JSON. Gửi. | `400 {"error":"Bad Request: Invalid payload format"}` |
+| **Thứ tự xác thực trước validation** | Xóa `WEBHOOK_SECRET` *và* chuyển loại Body sang Text. Gửi. | `401` (không phải `415`) — receiver xác thực trước khi kiểm tra media type, vì vậy các peer chưa xác thực không thể biết gì về content negotiation của endpoint. |
+| **mTLS handshake** | (Env Local-mTLS) → collection **Settings → Client Certs** → xóa mục cert localhost. Gửi. | Lỗi TLS handshake (Bruno hiển thị *"alert certificate required"* hoặc tương tự — request không bao giờ đến HTTP). Thêm lại cert để phục hồi. |
+
+Nếu bất kỳ cái nào trong số này trả về status khác với bảng, bạn đã tìm thấy lỗi trong receiver hoặc sự khác biệt thực sự giữa hai ví dụ triển khai — cả hai đều đáng điều tra.
+
+Bruno giữ một tab **History** cho mỗi request, vì vậy bạn có thể chuyển qua lại giữa phiên bản bị phá và phiên bản đúng để so sánh chúng cạnh nhau.
+
+## Thiết lập mTLS
+
+Bruno 3.x lưu trữ cấu hình client-certificate trong giao diện, không trong các file được kiểm soát phiên bản, vì vậy đây là thiết lập một lần cho mỗi máy.
+
+### Bước 1 — tạo cert demo
+
+`certs/` của collection là một symlink đã commit đến [`../../../examples/shared-certs/`](../../../examples/shared-certs/). Tạo các file thực tế một lần bằng shared script — cả hai webhook receiver đều lấy cùng output qua các symlink `certs/` của riêng chúng, vì vậy bạn không bao giờ phải chuyển đổi thủ công giữa các thiết lập Python/Node:
+
+```bash
+# From the repo root:
+(cd examples/shared-certs && ./gen-test-certs.sh)
+```
+
+Sau đây, `examples/bruno-collection/certs/client.crt` (được phân giải qua symlink) tồn tại và Bruno có thể nạp nó.
+
+### Bước 2 — đăng ký client cert trong Bruno
+
+Click tên collection (sidebar trái) → **Settings** → tab **Client Certs** → **Add Client Certificate**:
+
+| Trường | Giá trị |
+|---|---|
+| Domain | `127.0.0.1` |
+| Type | `cert` (PEM cert + PEM key) |
+| Cert file path | `certs/client.crt` |
+| Key file path | `certs/client.key` |
+| Passphrase | *(để trống)* |
+
+Lưu lại. Bruno sẽ trình `certs/client.crt` + `certs/client.key` mỗi khi host của một request khớp với `127.0.0.1`.
+
+> Tại sao dùng `127.0.0.1` mà không phải `localhost`? Ví dụ Python bind chỉ IPv4 (`run_simple("0.0.0.0", ...)`), và macOS phân giải `localhost` thành `::1` (IPv6) trước — kết nối thất bại với `ECONNREFUSED ::1:3000`. Các file env được cung cấp sử dụng `127.0.0.1` để tránh vấn đề này; SAN của demo server cert bao gồm `IP:127.0.0.1`, vì vậy TLS vẫn xác thực. Nếu bạn đã đổi env thành `localhost` và server của bạn bind dual-stack (ví dụ Node thì có), hãy đăng ký cert với `localhost` thay thế — hoặc thêm cả hai mục.
+
+### Bước 3 — chấp nhận demo CA tự ký
+
+CA được tạo bởi `gen-test-certs.sh` không có trong OS trust store của bạn, vì vậy Bruno sẽ từ chối TLS handshake theo mặc định. Tắt xác thực:
+
+- Tên collection → **Settings → Proxy** (hoặc **Network**, tên có thể khác) → bật/tắt **SSL Verification off**.
+- Hoặc, theo từng request: biểu tượng bánh răng bên cạnh URL → bỏ chọn **SSL Verification**.
+
+Đối với deployment production với cert do CA ký, hãy giữ xác thực bật.
+
+### Cách hoạt động (một đoạn tóm tắt)
+
+mTLS xảy ra ở lớp TLS *trước khi* bất kỳ HTTP nào được trao đổi. Server (Werkzeug/Express) trình cert của nó và yêu cầu client cert; Bruno trình `client.crt` + ký transcript handshake bằng `client.key`; server xác thực cert đó với CA pool của nó (`certs/ca.crt`); chỉ sau đó request mới đến handler của bạn, nơi Bearer-token auth chạy như một lớp thứ hai, độc lập. Thiếu client cert = lỗi TLS handshake (không có HTTP response). Bearer token sai nhưng client cert hợp lệ = `401`. Hai lớp độc lập với nhau — đó chính là ý nghĩa của bảo mật theo chiều sâu.
+
+## Tùy chỉnh collection
+
+### Chỉnh sửa body của một request
+
+Mở bất kỳ request nào → tab **Body** → chỉnh sửa JSON inline. Bruno hiển thị nó với JSON editor; lỗi cú pháp được tô sáng. Body được gửi nguyên văn, vì vậy bạn có thể thử nghiệm với các trường hợp biên (chuỗi rất dài, unicode, ký tự điều khiển nhúng) để xem receiver của bạn xử lý chúng như thế nào.
+
+### Thêm một request mới
+
+Click chuột phải vào collection trong sidebar → **New Request**. Dùng cùng template:
+
+```
+post {
+  url: {{WEBHOOK_URL}}
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{WEBHOOK_SECRET}}
+}
+
+body:json {
+  {
+    "event": { "action": "your_new_action" },
+    "pamsignal": {}
+  }
+}
+```
+
+Bruno sẽ lưu nó như `<Name>.bru` cạnh các file khác. `seq:` trong block `meta` điều khiển thứ tự sắp xếp trong sidebar.
+
+### Ghi đè giá trị env theo từng request
+
+Đôi khi bạn muốn một request dùng URL hoặc secret khác (ví dụ: để kiểm thử một staging endpoint). Mở request → tab **Vars** → thêm biến `Pre-request`. Các biến được định nghĩa ở đây sẽ che khuất các env var cho request đó.
+
+### Chuyển đổi nhanh giữa Python và Node receiver
+
+Cả hai receiver đều mặc định dùng cổng 3000, vì vậy không cần thay đổi gì — khởi động cái bạn muốn kiểm thử rồi gửi. Để kiểm thử cả hai cùng lúc, hãy chỉnh sửa các file env để dùng cổng khác nhau (ví dụ: `Local-Node` trên `:3000`, `Local-Python` trên `:3001`) và chạy receiver tương ứng trên cổng phù hợp.
+
+## Xử lý sự cố
+
+| Triệu chứng | Nguyên nhân có thể | Cách sửa |
+|---|---|---|
+| *"Unsupported collection format"* khi mở | Bạn đã click **Import Collection** thay vì **Open Collection** | Dùng **Open Collection** — thư mục đã ở định dạng `.bru` gốc của Bruno và không cần chuyển đổi |
+| Biến hiển thị `{{WEBHOOK_SECRET}}` theo nghĩa đen trong response/timeline | Chưa chọn environment, hoặc env thiếu biến đó | Chọn env từ dropdown (góc trên phải); xác nhận cả `WEBHOOK_URL` và `WEBHOOK_SECRET` đều được định nghĩa |
+| `ECONNREFUSED ::1:3000` | Env dùng `localhost`, nhưng receiver bind chỉ IPv4 (Python's `run_simple("0.0.0.0", ...)`); macOS phân giải `localhost` thành `::1` trước | Dùng `127.0.0.1` trong URL của env (các env đi kèm đã làm vậy); nếu bạn cũng đã cấu hình Client Cert với `localhost`, hãy cập nhật **Domain** của nó thành `127.0.0.1` để khớp |
+| `ECONNREFUSED` / "Failed to connect" (bất kỳ cổng/host nào khác) | Receiver không chạy, sai cổng, hoặc sai scheme (HTTP so với HTTPS env) | `curl -v {{WEBHOOK_URL}}` bên ngoài Bruno để xác nhận; kiểm tra xem scheme URL của env có khớp với những gì receiver đang lắng nghe không |
+| `401 Unauthorized` không mong muốn | `WEBHOOK_SECRET` của env không khớp với `.env` của receiver | Cập nhật một trong hai để khớp; khởi động lại receiver nếu bạn đã đổi `.env` (nó đọc khi khởi động) |
+| `TLS handshake / alert certificate required` | Đã chọn env mTLS nhưng chưa đăng ký client cert trong Bruno, hoặc `gen-test-certs.sh` chưa được chạy, hoặc symlink target bị hỏng | Chạy `(cd ../shared-certs && ./gen-test-certs.sh)`; kiểm tra lại mục **Client Certs**; xác minh `ls -L certs/client.crt` trỏ đến file thực |
+| `SELF_SIGNED_CERT_IN_CHAIN` / không thể xác minh cert | mTLS hoạt động nhưng SSL verification vẫn bật cho demo CA | Bật/tắt **SSL Verification off** cho demo (Bước 3 ở trên); đối với production, cài đặt CA thực |
+| `Parse Error: Expected HTTP/, RTSP/ or ICE/` | Sai scheme: Bruno gửi plain HTTP nhưng receiver phản hồi bằng TLS bytes (một TLS alert được đọc như rác bởi HTTP parser của Node) | Hoặc chuyển sang env **Local-mTLS**, hoặc comment out các dòng `TLS_*` trong `.env` của receiver và khởi động lại. Xác nhận với `curl -v http://localhost:3000/...` — nếu bạn thấy *"Received HTTP/0.9 when not allowed"*, server đang chạy HTTPS. |
+| Request "treo" khi Send | Tiến trình receiver bị crash hoặc bị block | Kiểm tra terminal của receiver để tìm stack trace; khởi động lại |
+
+Nếu có gì đó kỳ lạ khác xảy ra, tab **Timeline** của Bruno (cạnh *Response*) hiển thị toàn bộ trao đổi HTTP bao gồm request line, header, byte body và thời gian. Thường đủ để phát hiện sự không khớp.

--- a/docs/vi/examples/fail2ban.md
+++ b/docs/vi/examples/fail2ban.md
@@ -1,0 +1,416 @@
+# Hướng dẫn tích hợp Fail2ban
+
+> 🌐 [English](../../../examples/fail2ban/README.md) · **Tiếng Việt**
+
+Hướng dẫn này trình bày từng bước cách cấu hình [Fail2ban](https://github.com/fail2ban/fail2ban) để khi PAMSignal phát hiện một cuộc tấn công brute-force, địa chỉ IP của kẻ tấn công sẽ tự động bị chặn ở tầng firewall. Ví dụ bao gồm **Ubuntu 22.04+ / Debian 12+** và **CentOS Stream 9 / AlmaLinux 9 / Rocky Linux 9** (các lệnh tương tự cũng áp dụng cho Fedora 40+).
+
+Nếu bạn chưa từng dùng Fail2ban — không sao cả. Hướng dẫn này giải thích từng khái niệm ngay khi đề cập đến nó.
+
+> **Thời gian cần thiết:** ~10 phút.
+> **Điều kiện tiên quyết:** PAMSignal đã được cài đặt và bạn đã thấy ít nhất một dòng `pamsignal:` trong `journalctl -t pamsignal` (tức là daemon đang chạy). Nếu chưa, hãy hoàn tất phần [Quickstart](../README.md#bắt-đầu-nhanh) trước.
+
+---
+
+## Kết quả đạt được sau khi hoàn tất
+
+```mermaid
+graph TD
+    attacker["Attacker tries SSH login<br/>5 times in 5 minutes"]
+    pamsignal["PAMSignal<br/>writes BRUTE_FORCE_DETECTED<br/>to the systemd journal"]
+    fail2ban["Fail2ban<br/>sees the journal entry<br/>runs iptables / firewalld rule"]
+    kernel["Attacker's IP dropped at the kernel<br/>can't reach SSH (or any port) for 24h"]
+
+    attacker --> pamsignal
+    pamsignal --> fail2ban
+    fail2ban --> kernel
+
+    style attacker fill:#6c757d,stroke:#495057,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style fail2ban fill:#e76f51,stroke:#d62828,color:#fff
+    style kernel fill:#4a4e69,stroke:#22223b,color:#fff
+```
+
+Không cần duy trì regex phân tích log phức tạp, không cần đồng bộ ngưỡng giữa hai công cụ. PAMSignal đã xử lý hết phần tính toán; Fail2ban chỉ việc hành động theo tín hiệu đó.
+
+---
+
+## Fail2ban là gì?
+
+Fail2ban là một daemon Python nhỏ gọn, theo dõi các file log (hoặc systemd journal) để tìm các pattern biểu hiện cuộc tấn công, rồi thực thi một lệnh — thường là một quy tắc firewall — để chặn nguồn tấn công. Công cụ này đã là giải pháp phòng chống xâm nhập Linux thực tế trong hơn một thập kỷ.
+
+Các thuật ngữ chính bạn sẽ gặp trong hướng dẫn này:
+
+| Thuật ngữ | Ý nghĩa |
+|---|---|
+| **Filter** | Một regex nhận diện dòng log tấn công (`/etc/fail2ban/filter.d/*.conf`) |
+| **Jail** | Cấu hình liên kết một filter với một firewall action (`/etc/fail2ban/jail.d/*.conf`) |
+| **Backend** | Cách Fail2ban đọc log — ở đây là `systemd` journal |
+| **Action** | Việc Fail2ban làm khi bị kích hoạt — ở đây là "chặn IP này ở firewall" |
+| **`bantime`** | Thời gian lệnh cấm kéo dài (mặc định: 10 phút; ta đặt 24 giờ) |
+| **`findtime`** | Khoảng thời gian tính số lần khớp `maxretry` |
+| **`maxretry`** | Số lần khớp trong `findtime` để kích hoạt lệnh cấm — ta đặt là **1** vì PAMSignal đã tự đếm |
+| **`ignoreip`** | Danh sách IP an toàn — các IP không bao giờ bị cấm (hãy đặt IP nhà/văn phòng của bạn vào đây!) |
+
+Để tham khảo đầy đủ, xem [MANUAL của Fail2ban trên wiki chính thức](https://github.com/fail2ban/fail2ban/wiki/MANUAL).
+
+---
+
+## Tại sao kết hợp với PAMSignal?
+
+PAMSignal và Fail2ban bổ trợ cho nhau, không thay thế nhau:
+
+- **PAMSignal quan sát.** Nó phân tích mọi sự kiện PAM từ journal, theo dõi số lần đăng nhập thất bại theo IP, tính toán ngưỡng brute-force và gửi thông báo qua chat (Telegram, Slack, v.v.). Nó **không** can thiệp vào firewall.
+- **Fail2ban hành động.** Khi PAMSignal phát ra sự kiện `BRUTE_FORCE_DETECTED`, Fail2ban nhận thấy và lắp quy tắc firewall chặn IP đó.
+
+Điểm giao tiếp là một dòng log có cấu trúc duy nhất. Bạn không cần duy trì một `failregex` phức tạp cho output của `sshd` — PAMSignal đã hiểu sẵn các định dạng `sshd`, `sshd-session`, `sudo`, `su` và `login` trên nhiều distro khác nhau.
+
+---
+
+## Bước 1 — Cài đặt Fail2ban
+
+### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install fail2ban
+```
+
+Gói này đã tích hợp sẵn backend systemd-journal, dùng được ngay.
+
+### CentOS Stream 9 / AlmaLinux 9 / Rocky Linux 9 / Fedora 40+
+
+Fail2ban nằm trong kho EPEL trên các distro thuộc họ RHEL:
+
+```bash
+sudo dnf install epel-release
+sudo dnf install fail2ban fail2ban-firewalld
+```
+
+Gói con `fail2ban-firewalld` cấu hình Fail2ban sử dụng `firewalld` (firewall mặc định của RHEL) thay vì iptables thuần túy. Nếu không cài nó, Fail2ban sẽ fallback về iptables và có thể xung đột với các quy tắc của `firewalld`.
+
+### Kiểm tra sau khi cài (cả hai distro)
+
+```bash
+fail2ban-client --version
+sudo systemctl status fail2ban
+```
+
+Service đã được cài nhưng chưa được kích hoạt — ta sẽ khởi động sau khi cấu hình xong.
+
+---
+
+## Bước 2 — Cài đặt filter và jail của PAMSignal
+
+Hai file cấu hình trong thư mục này cho Fail2ban biết *cần theo dõi gì* và *phản ứng như thế nào*. Sao chép chúng vào đúng vị trí hệ thống:
+
+```bash
+# Từ thư mục này (examples/fail2ban/):
+sudo cp filter.d/pamsignal.conf /etc/fail2ban/filter.d/pamsignal.conf
+sudo cp jail.d/pamsignal.conf   /etc/fail2ban/jail.d/pamsignal.conf
+```
+
+### Chức năng của từng file
+
+**`/etc/fail2ban/filter.d/pamsignal.conf`** — regex nhận diện sự kiện brute-force của PAMSignal:
+
+```ini
+[Definition]
+failregex = pamsignal: BRUTE_FORCE_DETECTED ip=<HOST> attempts=\d+ window=\d+s user=.*
+ignoreregex =
+```
+
+Token `<HOST>` là đặc biệt — Fail2ban thay thế nó bằng một regex khớp với địa chỉ IPv4, IPv6 hoặc DNS, sau đó trích xuất địa chỉ khớp được làm "kẻ vi phạm" cần cấm. Xem [trang wiki Filter Files](https://github.com/fail2ban/fail2ban/wiki/Developing-Fail2Ban-Filters) để tìm hiểu DSL filter đầy đủ.
+
+**`/etc/fail2ban/jail.d/pamsignal.conf`** — jail kết nối filter với firewall action:
+
+```ini
+[pamsignal]
+enabled = true
+filter = pamsignal
+backend = systemd
+journalmatch = SYSLOG_IDENTIFIER=pamsignal
+banaction = iptables-allports
+maxretry = 1
+bantime = 24h
+```
+
+- `backend = systemd` — đọc từ journal thay vì file log.
+- `journalmatch = SYSLOG_IDENTIFIER=pamsignal` — chỉ nhìn vào các dòng do daemon PAMSignal phát ra. Hiệu quả hơn là đọc toàn bộ journal.
+- `maxretry = 1` — cấm ngay lập tức khi có một lần khớp. PAMSignal đã đếm đến ngưỡng rồi; một dòng `BRUTE_FORCE_DETECTED` **chính là** cảnh báo.
+- `bantime = 24h` — chặn IP trong 24 giờ. Thay bằng `1h`, `7d` hoặc `-1` (vĩnh viễn) tùy ý.
+
+---
+
+## Bước 3 — Chọn đúng firewall backend
+
+Dòng `banaction` trong jail quyết định *cách* IP bị chặn. Lựa chọn đúng phụ thuộc vào firewall mà distro của bạn đang dùng. Sửa `/etc/fail2ban/jail.d/pamsignal.conf` và đặt `banaction` tương ứng:
+
+### Ubuntu / Debian
+
+| Tình huống | `banaction` cần dùng |
+|---|---|
+| Bạn không dùng `ufw` (mặc định trên Ubuntu Server mới cài) | `iptables-allports` ← giá trị mặc định trong file jail của ta |
+| Bạn dùng `ufw` để quản lý firewall | `ufw` |
+| Bạn dùng `nftables` trực tiếp | `nftables-allports` |
+
+Nếu bạn đang dùng Ubuntu 22.04+ và đã từng chạy `sudo ufw enable`, hãy dùng action `ufw` — nếu không Fail2ban và `ufw` sẽ xung đột với nhau khi quản lý rule set.
+
+### CentOS / AlmaLinux / Rocky / Fedora
+
+| Tình huống | `banaction` cần dùng |
+|---|---|
+| Bạn dùng `firewalld` (mặc định họ RHEL) và đã cài `fail2ban-firewalld` | `firewallcmd-allports` |
+| Bạn dùng `iptables` thuần túy (cài cũ) | `iptables-allports` |
+| Bạn dùng `nftables` trực tiếp | `nftables-allports` |
+
+Hầu hết các bản cài RHEL-9 derivative đều chạy `firewalld` — hãy dùng `firewallcmd-allports`.
+
+Danh sách đầy đủ các action đi kèm nằm trong `/etc/fail2ban/action.d/`; xem [trang wiki Actions](https://github.com/fail2ban/fail2ban/wiki/Actions) để biết mô tả từng action.
+
+---
+
+## Bước 4 — Whitelist IP của bạn (làm việc này trước khi khởi động!)
+
+**Đây là bước quan trọng nhất.** Nếu bạn không whitelist bản thân và lỡ tay nhập sai mật khẩu từ máy quản trị, Fail2ban sẽ khóa bạn ra ngoài trong 24 giờ. Nói thẳng: bạn sẽ không thể SSH lại để gỡ lệnh cấm.
+
+Sửa `/etc/fail2ban/jail.d/pamsignal.conf` và thêm dòng `ignoreip`:
+
+```ini
+[pamsignal]
+enabled = true
+filter = pamsignal
+backend = systemd
+journalmatch = SYSLOG_IDENTIFIER=pamsignal
+banaction = iptables-allports
+maxretry = 1
+bantime = 24h
+
+# Never ban these — your home/office IP and any LAN ranges you trust.
+# Add one or more IPs / CIDRs separated by spaces.
+ignoreip = 127.0.0.1/8 ::1 203.0.113.42 10.0.0.0/8
+```
+
+Thay `203.0.113.42` bằng IP công khai thực của bạn (tìm bằng `curl ifconfig.me` từ máy bạn sẽ SSH đến). Chỉ thêm `10.0.0.0/8`, `192.168.0.0/16` hoặc `172.16.0.0/12` nếu bạn tin tưởng mọi thiết bị trong các dải LAN đó.
+
+Bạn cũng có thể đặt một whitelist *toàn cục* trong `/etc/fail2ban/jail.local` áp dụng cho mọi jail — đây là cách an toàn hơn nếu bạn định tạo thêm jail sau này. Xem [tài liệu `ignoreip`](https://github.com/fail2ban/fail2ban/wiki/MANUAL_0_8#jails) để biết cú pháp đầy đủ (chấp nhận CIDR, DNS, và shell-glob pattern).
+
+---
+
+## Bước 5 — Khởi động Fail2ban
+
+```bash
+sudo systemctl enable --now fail2ban
+sudo systemctl status fail2ban
+```
+
+`status` phải hiển thị `active (running)`. Nếu hiển thị `failed`, chuyển đến phần [Xử lý sự cố](#xử-lý-sự-cố).
+
+---
+
+## Bước 6 — Kiểm tra tích hợp
+
+### 6a. Xác nhận jail đã được nạp
+
+```bash
+sudo fail2ban-client status
+```
+
+Kết quả mong đợi:
+
+```
+Status
+|- Number of jail:	1
+`- Jail list:		pamsignal
+```
+
+Nếu `pamsignal` có trong danh sách jail, Fail2ban đã nạp cấu hình của bạn thành công.
+
+### 6b. Kiểm tra trạng thái hiện tại của jail
+
+```bash
+sudo fail2ban-client status pamsignal
+```
+
+Kết quả mong đợi (bản cài mới, chưa có lệnh cấm nào):
+
+```
+Status for the jail: pamsignal
+|- Filter
+|  |- Currently failed:	0
+|  |- Total failed:	0
+|  `- Journal matches:	SYSLOG_IDENTIFIER=pamsignal
+`- Actions
+   |- Currently banned:	0
+   |- Total banned:	0
+   `- Banned IP list:
+```
+
+### 6c. Chạy thử filter trên journal hiện có
+
+Đây là cách kiểm tra nhanh nhất — quét lịch sử PAMSignal thực tế của bạn và báo cáo bao nhiêu dòng filter sẽ khớp:
+
+```bash
+sudo fail2ban-regex systemd-journal /etc/fail2ban/filter.d/pamsignal.conf
+```
+
+Nếu bạn đã từng có sự kiện brute-force trong journal, bạn sẽ thấy kết quả tương tự:
+
+```
+Lines: 5 lines, 0 ignored, 3 matched, 2 missed
+```
+
+Nếu matched bằng 0 mà bạn biết chắc đã có sự kiện brute-force, xem phần [Xử lý sự cố](#xử-lý-sự-cố).
+
+### 6d. Kích hoạt lệnh cấm thực sự (từ máy khác)
+
+Từ một máy khác bạn có thể thử nghiệm (hoặc laptop kết nối mạng di động để có thể tắt dữ liệu nếu thử nghiệm bị hỏng), thực hiện nhiều lần SSH thất bại vào máy chủ:
+
+```bash
+# Từ máy thử nghiệm — thay your.server.example.com bằng máy chủ đang chạy PAMSignal
+for i in {1..6}; do
+  ssh -o PasswordAuthentication=yes -o PreferredAuthentications=password \
+      -o PubkeyAuthentication=no -o StrictHostKeyChecking=no \
+      nosuchuser@your.server.example.com
+done
+```
+
+Vài giây sau, trên máy chủ PAMSignal:
+
+```bash
+sudo fail2ban-client status pamsignal
+sudo iptables -L f2b-pamsignal -n     # hoặc: sudo firewall-cmd --list-rich-rules
+```
+
+"Banned IP list" lúc này phải chứa IP của máy thử nghiệm, và firewall phải hiển thị quy tắc DROP tương ứng.
+
+Để **gỡ cấm** IP thử nghiệm ngay lập tức:
+
+```bash
+sudo fail2ban-client set pamsignal unbanip 203.0.113.99
+```
+
+---
+
+## Tinh chỉnh
+
+Sau khi tích hợp hoạt động, bạn có thể muốn điều chỉnh hành vi. Sửa `/etc/fail2ban/jail.d/pamsignal.conf` và chạy `sudo systemctl reload fail2ban` sau mỗi thay đổi.
+
+| Cài đặt | Giá trị mặc định | Các lựa chọn thay thế phổ biến | Khi nào nên thay đổi |
+|---|---|---|---|
+| `bantime` | `24h` | `1h`, `7d`, `-1` (mãi mãi) | Giảm cho các IP hay thay đổi (residential dynamic); tăng cho máy chủ công khai muốn xử lý nghiêm |
+| `maxretry` | `1` | Giữ ở `1` | Đừng tăng — PAMSignal đã đếm rồi. Tăng lên 2+ đòi hỏi N×ngưỡng-PAMSignal lần thất bại mới cấm |
+| `findtime` | `10m` (mặc định Fail2ban) | Đặt khớp với `fail_window_sec` trong `pamsignal.conf` | Chỉ quan trọng khi `maxretry > 1`, điều mà bạn không nên làm — xem ở trên |
+| `banaction` | `iptables-allports` | `ufw`, `firewallcmd-allports`, `nftables-allports` | Khớp với firewall của distro (Bước 3) |
+
+### Tăng dần thời gian cấm cho kẻ tái phạm
+
+Tính năng [`bantime.increment`](https://github.com/fail2ban/fail2ban/wiki/MANUAL_0_8#actions) làm cho các lệnh cấm lặp lại kéo dài theo cấp số nhân. Thêm vào jail của bạn:
+
+```ini
+bantime.increment = true
+bantime.factor    = 2
+bantime.maxtime   = 30d
+```
+
+Lần cấm đầu là `bantime` (24h); lần hai là 48h; lần ba là 96h; giới hạn ở `maxtime` (30 ngày). Đây là cài đặt tuyệt vời cho các máy chủ tiếp xúc trực tiếp với internet công khai.
+
+---
+
+## Xử lý sự cố
+
+### "0 matched" từ `fail2ban-regex` nhưng tôi biết đã có sự kiện brute-force
+
+Kiểm tra xem PAMSignal có thực sự phát ra sự kiện không:
+
+```bash
+journalctl -t pamsignal --since "1 hour ago" | grep BRUTE_FORCE_DETECTED
+```
+
+Nếu không có kết quả: PAMSignal chưa phát hiện ngưỡng bị vượt qua. Tạm thời giảm `fail_threshold` trong `/etc/pamsignal/pamsignal.conf`, chạy `sudo systemctl reload pamsignal`, và kích hoạt thêm SSH thất bại.
+
+Nếu có kết quả nhưng regex không khớp: dán dòng đó vào [regex101.com](https://regex101.com) và kiểm tra với `failregex` từ `/etc/fail2ban/filter.d/pamsignal.conf`.
+
+### `fail2ban` không khởi động được với lỗi "no module named systemd"
+
+Trên các distro họ RHEL, backend systemd journal cần `python3-systemd`:
+
+```bash
+sudo dnf install python3-systemd
+sudo systemctl restart fail2ban
+```
+
+Trên Ubuntu dependency này thường được kéo vào tự động; nếu không:
+
+```bash
+sudo apt install python3-systemd
+```
+
+### "Tôi bị khóa ra ngoài" — khôi phục khẩn cấp
+
+Nếu bạn có quyền truy cập console (serial console của cloud provider, hypervisor, bàn phím vật lý):
+
+```bash
+sudo fail2ban-client unban --all                    # gỡ mọi lệnh cấm trong tất cả jail
+sudo systemctl stop fail2ban                        # ngăn bị cấm lại trong khi sửa ignoreip
+# … sửa /etc/fail2ban/jail.d/pamsignal.conf và thêm IP của bạn vào ignoreip …
+sudo systemctl start fail2ban
+```
+
+Nếu không có quyền truy cập console — hãy chờ hết `bantime` (mặc định 24h) hoặc liên hệ cloud provider để reset ngoài băng tần.
+
+### `firewalld` và `iptables-allports` xung đột nhau
+
+Bạn thấy Fail2ban áp dụng quy tắc nhưng không có hiệu lực, hoặc các quy tắc `firewalld` cứ ghi đè lên. Trên họ RHEL, chuyển jail sang `banaction = firewallcmd-allports` (Bước 3). Trên Ubuntu với `ufw`, chuyển sang `banaction = ufw`. Đừng chạy hai firewall manager xung đột nhau.
+
+### Thời gian cấm quá ngắn / quá dài
+
+Sửa `bantime` trong `/etc/fail2ban/jail.d/pamsignal.conf` và reload:
+
+```bash
+sudo systemctl reload fail2ban
+```
+
+Reload giữ nguyên các lệnh cấm hiện có; `restart` đầy đủ sẽ xóa chúng.
+
+---
+
+## Cơ chế hoạt động bên dưới
+
+```mermaid
+graph TD
+    sshd["sshd · sudo · su · login<br/>PAM-stack daemons emit auth events"]
+    journal[("systemd journal<br/>structured · queryable · persistent")]
+    pamsignal["PAMSignal daemon<br/>parses · counts · thresholds · alerts"]
+    fail2ban["Fail2ban (this guide)<br/>journalmatch=SYSLOG_IDENTIFIER=pamsignal<br/>runs iptables / firewall-cmd / ufw"]
+    netfilter["Kernel netfilter<br/>attacker's IP dropped before reaching sshd"]
+
+    sshd -- "PAM auth events" --> journal
+    journal -- "sd_journal_* (reads)" --> pamsignal
+    pamsignal -- "sd_journal_send<br/>BRUTE_FORCE_DETECTED" --> journal
+    journal -- "tails for regex match" --> fail2ban
+    fail2ban -- "drop rule" --> netfilter
+
+    style sshd fill:#6c757d,stroke:#495057,color:#fff
+    style journal fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style fail2ban fill:#e76f51,stroke:#d62828,color:#fff
+    style netfilter fill:#4a4e69,stroke:#22223b,color:#fff
+```
+
+Hai daemon hoàn toàn độc lập với nhau: PAMSignal không biết Fail2ban tồn tại, và Fail2ban không biết PAMSignal tồn tại. Chúng giao tiếp qua structured journal — bền bỉ, an toàn cho nhiều reader đồng thời, và là event log chuẩn tắc trên Linux có systemd. Nếu bạn gỡ cài đặt Fail2ban vào ngày mai, PAMSignal vẫn hoạt động bình thường.
+
+### Tại sao ta không cấm sự kiện brute-force từ actor nội bộ
+
+PAMSignal phát ra sự kiện brute-force cho cả tấn công từ xa (theo IP) lẫn tấn công từ actor nội bộ (theo username, khi ai đó liên tục dùng `sudo` từ phiên local). Fail2ban chỉ có thể chặn IP — nó không thể vô hiệu hóa tài khoản UNIX nội bộ — vì vậy filter của ta chỉ cố tình khớp với sự kiện có khóa là IP. Các sự kiện actor nội bộ vẫn xuất hiện trong journal và chat alert của bạn, nhưng không kích hoạt Fail2ban.
+
+Nếu bạn cần khóa actor nội bộ, đó là việc của `pam_tally2` / `pam_faillock` trong PAM stack của bạn, không phải Fail2ban.
+
+---
+
+## Đọc thêm
+
+- [README dự án Fail2ban](https://github.com/fail2ban/fail2ban) — ma trận cài đặt, distro hỗ trợ, mã nguồn
+- [MANUAL Fail2ban (wiki chính thức)](https://github.com/fail2ban/fail2ban/wiki/MANUAL) — toàn bộ directive, backend và action được giải thích
+- [Tham khảo Filter Files](https://github.com/fail2ban/fail2ban/wiki/Developing-Fail2Ban-Filters) — DSL regex và bảng token (`<HOST>`, `<ADDR>`, `<F-USER>`, v.v.)
+- [Tham khảo Actions](https://github.com/fail2ban/fail2ban/wiki/Actions) — mọi `banaction` tích hợp sẵn và cách tự viết
+- [Mô hình threat của PAMSignal — Hướng dẫn Operator §7](../threat-model.md#hướng-dẫn-cho-operator) — lý do ta khuyến nghị kết hợp quan sát với hành động

--- a/docs/vi/examples/grafana.md
+++ b/docs/vi/examples/grafana.md
@@ -1,0 +1,245 @@
+# PAMSignal — Tích hợp Grafana
+
+> 🌐 [English](../../../examples/grafana/README.md) · **Tiếng Việt**
+
+Giám sát SSH/sudo/su/login toàn bộ fleet với PAMSignal, hiển thị trên Grafana.
+
+![PAMSignal dashboard](../../../assets/grafana-dashboard.png)
+
+Thư mục này cung cấp mọi thứ operator cần để đưa các sự kiện PAMSignal từ fleet Linux vào một Grafana dashboard duy nhất:
+
+- `alloy.river` — cấu hình [Grafana Alloy](https://grafana.com/docs/alloy/latest/) cho môi trường production. Cài một instance trên mỗi host. Scrape `SYSLOG_IDENTIFIER=pamsignal` từ systemd journald và đẩy lên Loki.
+- `dashboards/pamsignal-v1.json` — dashboard, sẵn sàng provisioning (datasource UID hardcode là `loki`, khớp với file provisioning đi kèm).
+- `dashboards/pamsignal-v1.grafana-com.json` — cùng dashboard, định dạng "shared externally" với placeholder `${DS_LOKI}` + các block `__inputs`/`__requires`. Upload **file này** lên grafana.com hoặc dùng tính năng UI Import của Grafana (sẽ hỏi bạn chọn datasource Loki của mình).
+- `alerts.yaml` — bốn alert rule Grafana-native.
+- `docker-compose.yml` — stack local một lệnh để bạn xem trước dashboard trước khi quyết định deploy thực sự.
+- `verify.sh` — kiểm tra sức khỏe pipeline một lần.
+
+Toàn bộ thiết kế — schema, kế hoạch label-cardinality, lý do panel — nằm trong
+[`docs/grafana-integration.md`](../grafana-integration.md).
+
+---
+
+## Dùng thử trong 60 giây (không cần fleet Linux)
+
+Bạn chỉ cần Docker. Vậy thôi.
+
+```bash
+cd examples/grafana
+docker compose up -d
+```
+
+Mở **http://localhost:3000** — anonymous Admin, không cần đăng nhập. Dashboard nằm trong thư mục **PAMSignal**. Các sự kiện tổng hợp được stream vào với tốc độ ~2/giây; các đợt brute-force bùng phát trung bình mỗi ~25 giây.
+
+Để dừng và xóa (bao gồm cả volume):
+
+```bash
+docker compose down -v
+```
+
+### Thành phần trong stack local
+
+| Service | Vai trò |
+| --- | --- |
+| `loki` | Loki single-binary, lưu trữ filesystem, giữ log 7 ngày |
+| `alloy` | Đọc sự kiện JSONL từ shared volume; phản ánh đúng hình dạng pipeline production |
+| `grafana` | Anonymous Admin, được provisioning với Loki + dashboard |
+| `renderer` | Image renderer cho URL `/render` (dùng bởi `assets/grafana-dashboard.png`) |
+| `synthetic` | Container Python tạo sự kiện pamsignal thực tế |
+
+Producer tổng hợp đẩy sự kiện vào Loki qua hai đường đồng thời:
+
+1. **Direct push** vào `loki/api/v1/push` — mô phỏng những gì một HTTP-based agent sẽ làm.
+2. **Append vào shared file** mà `alloy` đang tail — chứng minh pipeline Alloy theo kiểu production cũng hoạt động ở local.
+
+Cả hai đường đều landing vào cùng một Loki instance với cùng label set, nên dashboard hoạt động như nhau với cả hai nguồn.
+
+---
+
+## Deploy thực sự
+
+### 1. Dựng Loki + Grafana
+
+Nếu bạn chưa có, cách đơn giản nhất là
+[Grafana Cloud](https://grafana.com/products/cloud/) (gói miễn phí đã có Loki).
+Tự host bằng [docker-compose](https://grafana.com/docs/loki/latest/setup/install/docker/)
+hoặc [Helm](https://grafana.com/docs/loki/latest/setup/install/helm/).
+
+### 2. Cài Alloy trên mỗi host PAMSignal
+
+```bash
+# Debian/Ubuntu — từ APT repo của grafana.com
+curl -fsSL https://apt.grafana.com/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
+  | sudo tee /etc/apt/sources.list.d/grafana.list
+sudo apt-get update && sudo apt-get install alloy
+
+# RHEL/Fedora/Alma/Rocky — từ RPM repo của grafana.com
+# https://grafana.com/docs/alloy/latest/set-up/install/linux/
+```
+
+Gói Alloy đi kèm một unit systemd `alloy`; user mà nó chạy dưới
+(`alloy:alloy`) phải thuộc group `systemd-journal` để đọc journald:
+
+```bash
+sudo usermod -aG systemd-journal alloy
+```
+
+### 3. Đặt `alloy.river` vào đúng chỗ
+
+```bash
+sudo cp alloy.river /etc/alloy/config.alloy
+# Sửa URL endpoint loki.write cho Loki instance của bạn
+sudo $EDITOR /etc/alloy/config.alloy
+sudo systemctl restart alloy
+```
+
+Kiểm tra Alloy hoạt động ổn:
+
+```bash
+sudo journalctl -u alloy -f
+# Hoặc truy cập http://<host>:12345 để xem Alloy UI
+```
+
+### 4. Import dashboard
+
+**Tùy chọn A — provision** (khuyến nghị cho Grafana tự host):
+
+```bash
+sudo cp dashboards/pamsignal-v1.json /var/lib/grafana/dashboards/
+sudo cp ../grafana/provisioning/dashboards/pamsignal.yml \
+        /etc/grafana/provisioning/dashboards/
+sudo systemctl restart grafana-server
+```
+
+**Tùy chọn B — import qua UI**: Grafana → Dashboards → New → Import → upload
+`dashboards/pamsignal-v1.grafana-com.json` (phiên bản có placeholder `${DS_LOKI}`).
+Chọn datasource Loki của bạn khi được hỏi.
+
+### 5. Cấu hình alert
+
+Sửa `alerts.yaml` để trỏ `folder:` đến Grafana folder bạn muốn, sau đó
+provision qua `/etc/grafana/provisioning/alerting/` hoặc import qua
+Grafana UI (Alerting → Alert rules → Import).
+
+Sau khi import, gắn từng rule vào một contact point (Slack, Telegram,
+PagerDuty, email). Bốn rule:
+
+| Rule | Severity | Kích hoạt khi |
+| --- | --- | --- |
+| Brute-force detected | critical | Có bất kỳ `event_action="brute_force_detected"` nào trong 5 phút |
+| Root login over SSH | high | Có bất kỳ lần đăng nhập SSH thành công bằng root trong 10 phút |
+| ≥10 failed logins from one IP | high | Số lần thất bại từ một IP tăng đột biến trong 5 phút |
+| Host stopped reporting | medium | Đã hoạt động trong 1h gần đây nhưng im lặng 10 phút |
+
+### 6. Kiểm tra
+
+Từ bất kỳ máy nào có thể kết nối đến Loki và Grafana:
+
+```bash
+LOKI_URL=https://loki.yourdomain GRAFANA_URL=https://grafana.yourdomain ./verify.sh
+```
+
+Kết quả mong đợi kết thúc bằng `✅ Pipeline healthy`. Nếu không, script sẽ cho biết bước nào bị hỏng.
+
+---
+
+## Kiến trúc
+
+```mermaid
+graph LR
+    pamsignal["PAMSignal<br/>(per host)"]
+    journald[("systemd-journald<br/>(per host)")]
+    alloy["Grafana Alloy<br/>(per host)"]
+    loki[("Loki")]
+    grafana["Grafana"]
+    operator["🧑‍💻 Operator"]
+
+    pamsignal -- "sd_journal_send<br/>(ECS fields)" --> journald
+    journald -- "SYSLOG_IDENTIFIER=pamsignal" --> alloy
+    alloy -- "Loki push API<br/>(4 labels)" --> loki
+    loki -- "LogQL queries" --> grafana
+    grafana -- "fleet dashboard<br/>+ alerts" --> operator
+
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style alloy fill:#457b9d,stroke:#1d3557,color:#fff
+    style loki fill:#e9c46a,stroke:#f4a261,color:#000
+    style grafana fill:#e76f51,stroke:#d62828,color:#fff
+    style operator fill:#6c757d,stroke:#495057,color:#fff
+```
+
+**Lý do thiết kế theo hình dạng này:**
+
+- PAMSignal đã ghi các structured field theo chuẩn ECS vào journald
+  (`EVENT_ACTION`, `SOURCE_IP`, `USER_NAME`, ...). Không cần thay đổi gì ở daemon.
+- Alloy đọc journald với `format_as_json=true`, chuyển mỗi field thành chữ thường dạng `__journal_<field>`, và một relabel pass chỉ đẩy đúng bốn trường lên thành Loki label (`app`, `host`, `service`, `event_action`). Mọi thứ còn lại ở trong phần thân JSON và được parse lúc query. Xem
+  [kế hoạch label cardinality](../grafana-integration.md#kế-hoạch-label-cardinality).
+- Loki index bốn label đó — `5 service × 6 action × fleet_size`
+  stream. Hoạt động tốt đến hàng nghìn host.
+
+---
+
+## Xử lý sự cố
+
+### Label Loki không hiển thị
+
+Chạy `verify.sh --loki-only` trước để cô lập Alloy. Nếu sự kiện probe đến được Loki với đúng label, vấn đề nằm ở relabel pass của Alloy.
+
+Kiểm tra tên các field `__journal_*`. Journald chuyển tên field tùy chỉnh thành chữ thường từ `SERVICE_NAME` sang `__journal_service_name`. Nếu tên label bị sai, relabel rule trong `alloy.river` sẽ không khớp.
+
+### Các panel dashboard trống
+
+Kiểm tra time picker. Mặc định là "last 6h" — nếu stack vừa khởi động, hãy thu ngắn xuống "last 5m".
+
+Mở **Explore** của Grafana với datasource Loki và chạy `{app="pamsignal"}`.
+Nếu không có kết quả, dữ liệu chưa đến được Loki. Kiểm tra log của `alloy` và `loki`.
+
+### Alloy không đọc được journald
+
+```
+err="open /run/log/journal: permission denied"
+```
+
+User `alloy` phải thuộc group `systemd-journal`, HOẶC unit phải chạy với
+`Group=systemd-journal`. Gói được đóng gói sẵn đã xử lý trường hợp đầu miễn là
+bạn đã chạy `usermod -aG systemd-journal alloy`.
+
+### Label `service_name` xuất hiện bên cạnh `service`
+
+Loki 3.x tự động suy ra `service_name` để theo dõi log-volume. Vô hại — dashboard query trực tiếp `service=`. Nếu muốn bỏ đi, đặt `discover_log_levels: false` và `discover_service_name: false` trong block `loki.write` của bạn.
+
+### Panel brute-force hiển thị 0 nhưng tôi biết đã có sự kiện brute-force
+
+PAMSignal chỉ ghi `EVENT_ACTION=brute_force_detected` khi đạt `fail_threshold` nội bộ. Nếu bạn đặt ngưỡng cao (ví dụ: 50), các host riêng lẻ sẽ không kích hoạt và panel vẫn ở 0. Rule #3 trong `alerts.yaml` là lưới an toàn cho trường hợp này — nó kích hoạt trên các đợt tăng đột biến login thất bại ngay cả khi PAMSignal chưa leo thang.
+
+---
+
+## Ghi chú tinh chỉnh
+
+- **Retention.** Mặc định trong `config/loki-config.yml` là 7 ngày. Tăng lên để phục vụ audit/compliance — xem [tài liệu retention của Loki](https://grafana.com/docs/loki/latest/operations/storage/retention/).
+- **Cardinality.** Đừng đưa `source_ip` hay `user_name` lên làm Loki label. Cả hai không giới hạn và sẽ làm bùng nổ index. Dashboard parse chúng lúc query time bằng `| json` — hãy giữ nguyên như vậy.
+- **Nhiễu session_closed.** Việc dùng sudo/su nhiều sẽ tạo ra nhiều sự kiện `session_closed`. Có một `stage.drop` đang bị comment trong `alloy.river` nếu bạn muốn bỏ chúng ở tầng Alloy.
+- **Alert ngoài giờ hành chính.** Không được ship sẵn — policy khác nhau tùy tổ chức. Thêm rule với bộ lọc kiểu CRON qua điều kiện thời gian trong ngày của Grafana nếu bạn cần.
+
+---
+
+## Đóng góp thay đổi
+
+PRs luôn được chào đón:
+
+- Panel mới — thêm vào `dashboards/pamsignal-v1.json`, kèm screenshot thay đổi.
+- Alert rule mới — thêm vào `alerts.yaml` với một hàng trong bảng ở trên.
+- Ghi chú cài đặt Alloy cho distro cụ thể — thêm vào phần "Deploy thực sự".
+
+CI (`.github/workflows/grafana-integration.yml`) dựng stack docker-compose
+trên mỗi PR chạm vào thư mục này và chạy `verify.sh`.
+
+---
+
+## Liên kết liên quan
+
+- [Grafana Alloy](https://grafana.com/docs/alloy/latest/)
+- [Loki LogQL](https://grafana.com/docs/loki/latest/logql/)
+- [README chính của PAMSignal](../README.md)
+- [Tài liệu thiết kế](../grafana-integration.md)

--- a/docs/vi/examples/nodejs-webhook.md
+++ b/docs/vi/examples/nodejs-webhook.md
@@ -1,0 +1,222 @@
+# PAMSignal Node.js Webhook Receiver
+
+> 🌐 [English](../../../examples/nodejs-webhook/README.md) · **Tiếng Việt**
+
+Đây là ví dụ sẵn dùng về một Custom Webhook receiver được xây dựng bằng **TypeScript**, Node.js và Express. Receiver nhận các ECS JSON alert có cấu trúc từ PAMSignal và xử lý chúng.
+
+Ví dụ này áp dụng các best practice của Express, bao gồm:
+- **TypeScript** để đảm bảo type safety nghiêm ngặt và cú pháp hiện đại
+- **Security Headers** sử dụng `helmet`
+- **Request Logging** sử dụng `morgan`
+- **Authentication** bằng Bearer token bí mật
+
+## 🚀 Bắt đầu
+
+### 1. Cài đặt Dependencies
+
+Đảm bảo bạn đã cài Node.js, sau đó chạy:
+
+```bash
+npm install
+```
+
+### 2. Cấu hình Environment
+
+Sao chép file environment mẫu và đặt một secret token mạnh:
+
+```bash
+cp .env.example .env
+```
+
+Chỉnh sửa `.env` và đặt `WEBHOOK_SECRET` thành một chuỗi ngẫu nhiên.
+
+### 3. Build & Chạy Server
+
+```bash
+# Compile TypeScript sang JavaScript (xuất ra thư mục dist/)
+npm run build
+
+# Chạy code đã compile cho môi trường production
+npm start
+
+# Để phát triển (tự khởi động lại khi file thay đổi, không cần build)
+npm run dev
+```
+
+Server sẽ bắt đầu lắng nghe tại `http://localhost:3000/webhook/pamsignal`.
+
+## ⚙️ Tích hợp với PAMSignal
+
+Express app này bắt buộc sử dụng `Authorization: Bearer <token>` để tránh lộ secret qua access log của URL. PAMSignal hỗ trợ điều này trực tiếp thông qua config key `webhook_auth_header` — không cần reverse proxy.
+
+### Cấu hình trực tiếp (khuyến nghị)
+
+Chỉnh sửa `/etc/pamsignal/pamsignal.conf`:
+
+```ini
+webhook_url = https://your-receiver.example.com/webhook/pamsignal
+webhook_auth_header = Authorization: Bearer your_super_secret_token_here
+```
+
+Reload PAMSignal để áp dụng các thay đổi:
+
+```bash
+sudo systemctl reload pamsignal
+```
+
+Giá trị header được truyền cho curl qua một memfd-backed config file, vì vậy token không bao giờ xuất hiện trong `/proc/<pid>/cmdline`. Đặt quyền `0640 root:pamsignal` trên `pamsignal.conf` để giữ giá trị không đọc được từ disk với các user không phải daemon.
+
+### Reverse proxy (thay thế)
+
+Nếu bạn đã đặt receiver phía sau Nginx/Caddy/Traefik (TLS termination, rate-limit, v.v.), bạn có thể để proxy inject header thay thế:
+
+- Proxy: `proxy_set_header Authorization "Bearer your_super_secret_token_here";`
+- pamsignal.conf: `webhook_url = https://your-secure-proxy.local/webhook/pamsignal` (bỏ qua `webhook_auth_header`)
+
+### Mutual TLS (nâng cao)
+
+Nếu bạn đã vận hành một internal PKI, ví dụ này có thể chạy như một HTTPS receiver thực thi mTLS, kết hợp với config `webhook_client_cert` / `webhook_client_key` của pamsignal. Server tự động chọn HTTPS thay vì plain HTTP khi các TLS env var được thiết lập.
+
+#### Demo end-to-end cục bộ
+
+```bash
+# 1. Generate a CA + server cert + client cert in the shared dir.
+#    The `./certs/` path here is a symlink to ../shared-certs/, so the
+#    Python example and the Bruno collection pick up the same files.
+(cd ../shared-certs && ./gen-test-certs.sh)
+
+# 2. Configure this example to listen on HTTPS and require a client cert.
+cat >> .env <<'EOF'
+TLS_KEY_PATH=./certs/server.key
+TLS_CERT_PATH=./certs/server.crt
+TLS_CLIENT_CA_PATH=./certs/ca.crt
+TLS_REQUIRE_CLIENT_CERT=true
+EOF
+
+# 3. Start the receiver.
+npm run dev   # or: npm run build && npm start
+```
+
+Bạn sẽ thấy `🔐 PAMSignal Webhook Receiver listening on https://localhost:3000/webhook/pamsignal (mTLS — client cert required)`.
+
+#### Cấu hình pamsignal
+
+Trong `/etc/pamsignal/pamsignal.conf`:
+
+```ini
+webhook_url = https://localhost:3000/webhook/pamsignal
+webhook_auth_header = Authorization: Bearer your_super_secret_token_here
+webhook_client_cert = /absolute/path/to/certs/client.crt
+webhook_client_key  = /absolute/path/to/certs/client.key
+# Required because the demo CA isn't in the system trust store.
+webhook_ca_bundle   = /absolute/path/to/certs/ca.crt
+```
+
+Reload pamsignal (`sudo systemctl reload pamsignal`) và kích hoạt một event — receiver sẽ ghi log nó. Một request từ bất kỳ client nào không có cert hợp lệ (ví dụ: `curl https://localhost:3000/webhook/pamsignal`) sẽ bị từ chối ngay tại TLS handshake, trước khi đến được Express.
+
+#### Cấu hình cho môi trường production
+
+Cho các deployment trên môi trường production, hãy thay `./certs/*` bằng các đường dẫn được quản lý bởi cert pipeline của bạn (cert-manager, certbot, `systemd-creds`, internal CA + ACME, v.v.). Bốn env var và các config key `webhook_*` không thay đổi. `gen-test-certs.sh` chỉ dùng cho kiểm thử local/CI — không đưa output của nó lên production.
+
+mTLS kết hợp cộng thêm với `webhook_auth_header` nếu receiver muốn cả hai (mTLS để xác minh danh tính service ở transport layer, Bearer để ủy quyền từng request). Express middleware trong ví dụ này kiểm tra Bearer token bất kể transport, vì vậy một deployment chỉ dùng mTLS có thể đơn giản để `WEBHOOK_SECRET` trống (hoặc đặt cả hai để tăng cường bảo mật theo chiều sâu).
+
+## 🛠️ Triển khai như Systemd Daemon
+
+Để chạy trên production, bạn nên chạy webhook receiver này như một background service để nó tự động khởi động khi boot và khởi động lại nếu bị crash.
+
+1. Đảm bảo bạn đã compile code:
+   ```bash
+   npm run build
+   ```
+
+2. Tạo một systemd service file. Mở `/etc/systemd/system/pamsignal-webhook.service`:
+   ```bash
+   sudo nano /etc/systemd/system/pamsignal-webhook.service
+   ```
+
+3. Dán cấu hình sau đây. Hãy chắc chắn cập nhật `WorkingDirectory` thành đường dẫn thực tế của project và `User` thành user non-root thực tế của bạn:
+
+   ```ini
+   [Unit]
+   Description=PAMSignal Node.js Webhook Receiver
+   After=network.target
+
+   [Service]
+   Type=simple
+   # Update this to the user you want to run the Node.js process as
+   User=www-data
+   # Update this to the absolute path of this example directory
+   WorkingDirectory=/opt/pamsignal-nodejs-webhook
+   # Path to your Node.js executable (find it with `which node`)
+   ExecStart=/usr/bin/node dist/index.js
+   Restart=on-failure
+   RestartSec=5
+   
+   # Load the environment variables from the .env file
+   EnvironmentFile=/opt/pamsignal-nodejs-webhook/.env
+
+   # Security Hardening
+   NoNewPrivileges=yes
+   ProtectSystem=strict
+   ProtectHome=yes
+   PrivateTmp=yes
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+4. Bật và khởi động service:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now pamsignal-webhook
+   sudo systemctl status pamsignal-webhook
+   ```
+
+5. Xem log theo thời gian thực:
+   ```bash
+   journalctl -u pamsignal-webhook -f
+   ```
+
+## 🧪 Kiểm thử thủ công
+
+### Dùng Bruno API Client
+
+Một **Bruno** collection dùng chung nằm tại [`../../../examples/bruno-collection/`](../../../examples/bruno-collection/) và hoạt động với bất kỳ receiver nào triển khai PAMSignal webhook contract — ví dụ Node.js này và ví dụ Python Flask đều đủ điều kiện. Collection đi kèm hai environment:
+
+- **Local** — plain HTTP, chỉ dùng Bearer token
+- **Local-mTLS** — HTTPS với client cert (kết hợp với `TLS_REQUIRE_CLIENT_CERT=true` ở đây)
+
+Xem [`bruno-collection.md`](bruno-collection.md) để biết cách thiết lập cert symlink. Bắt đầu nhanh:
+
+1. Tải [Bruno](https://www.usebruno.com/).
+2. Click **Open Collection** (không phải *Import Collection* — đường dẫn đó dùng cho Postman/OpenAPI JSON) và chọn thư mục `examples/bruno-collection`.
+3. Chọn environment từ dropdown (góc trên bên phải) — `Local` hoặc `Local-mTLS`.
+4. Cập nhật `WEBHOOK_SECRET` của environment đã chọn để khớp với `.env` của bạn và click **Send**.
+
+### Dùng Curl
+
+Bạn cũng có thể mô phỏng một PAMSignal brute-force alert bằng `curl` để kiểm thử Express server:
+
+```bash
+# Testing with Bearer Token header
+curl -X POST http://localhost:3000/webhook/pamsignal \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer your_super_secret_token_here" \
+     -d '{
+       "event": { "action": "brute_force_detected" },
+       "source": { "ip": "203.0.113.50" },
+       "pamsignal": { "attempts": 12, "window_sec": 300 }
+     }'
+```
+
+Bạn sẽ thấy event được parse và ghi log đẹp trong stream `journalctl` hoặc console Node.js của bạn!
+
+## ✅ Unit Tests
+
+Project này bao gồm một bộ Jest test toàn diện kiểm tra xác thực (Bearer token) và payload validation.
+
+Để chạy tests:
+
+```bash
+npm run test
+```

--- a/docs/vi/examples/python-webhook.md
+++ b/docs/vi/examples/python-webhook.md
@@ -1,0 +1,230 @@
+# PAMSignal Python Webhook Receiver
+
+> 🌐 [English](../../../examples/python-webhook/README.md) · **Tiếng Việt**
+
+Đây là ví dụ sẵn dùng về một Custom Webhook receiver được xây dựng bằng **Python** và **Flask**. Receiver nhận các ECS JSON alert có cấu trúc từ PAMSignal và xử lý chúng. Đây là phiên bản Python tương đương với ví dụ `examples/nodejs-webhook/` và cung cấp cùng endpoint contract, env var, và hành vi mTLS.
+
+Ví dụ này bao gồm:
+- **Flask** cho HTTP layer
+- **Authentication** bằng Bearer token bí mật (không lộ secret qua URL)
+- Tùy chọn **HTTPS / mutual TLS** khi kết hợp với `webhook_client_cert` / `webhook_client_key` trong `pamsignal.conf`
+- **[uv](https://docs.astral.sh/uv/)** để quản lý dependency và virtualenv
+
+## 🚀 Bắt đầu
+
+### 1. Cài đặt uv
+
+Nếu bạn chưa có:
+
+```bash
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Xem [tài liệu cài đặt uv](https://docs.astral.sh/uv/getting-started/installation/) để biết các phương pháp khác.
+
+### 2. Cài đặt Dependencies
+
+Từ thư mục này:
+
+```bash
+uv sync
+```
+
+`uv sync` tạo `.venv/` và cài đặt mọi thứ từ `pyproject.toml` (bao gồm cả các dev tool như `pytest`).
+
+### 3. Cấu hình Environment
+
+Sao chép file environment mẫu và đặt một secret token mạnh:
+
+```bash
+cp .env.example .env
+```
+
+Chỉnh sửa `.env` và đặt `WEBHOOK_SECRET` thành một chuỗi ngẫu nhiên (ví dụ: `openssl rand -hex 32`).
+
+### 4. Chạy Server
+
+```bash
+uv run python src/server.py
+```
+
+Server sẽ bắt đầu lắng nghe tại `http://localhost:3000/webhook/pamsignal`.
+
+## ⚙️ Tích hợp với PAMSignal
+
+Flask app này bắt buộc sử dụng `Authorization: Bearer <token>` để tránh lộ secret qua access log của URL. PAMSignal hỗ trợ điều này trực tiếp thông qua config key `webhook_auth_header` — không cần reverse proxy.
+
+### Cấu hình trực tiếp (khuyến nghị)
+
+Chỉnh sửa `/etc/pamsignal/pamsignal.conf`:
+
+```ini
+webhook_url = https://your-receiver.example.com/webhook/pamsignal
+webhook_auth_header = Authorization: Bearer your_super_secret_token_here
+```
+
+Reload PAMSignal để áp dụng các thay đổi:
+
+```bash
+sudo systemctl reload pamsignal
+```
+
+Giá trị header được truyền cho curl qua một memfd-backed config file, vì vậy token không bao giờ xuất hiện trong `/proc/<pid>/cmdline`. Đặt quyền `0640 root:pamsignal` trên `pamsignal.conf` để giữ giá trị không đọc được từ disk với các user không phải daemon.
+
+### Reverse proxy (thay thế)
+
+Nếu bạn đã đặt receiver phía sau Nginx/Caddy/Traefik (TLS termination, rate-limit, v.v.), bạn có thể để proxy inject header thay thế:
+
+- Proxy: `proxy_set_header Authorization "Bearer your_super_secret_token_here";`
+- pamsignal.conf: `webhook_url = https://your-secure-proxy.local/webhook/pamsignal` (bỏ qua `webhook_auth_header`)
+
+### Mutual TLS (nâng cao)
+
+Nếu bạn đã vận hành một internal PKI, ví dụ này có thể chạy như một HTTPS receiver thực thi mTLS, kết hợp với config `webhook_client_cert` / `webhook_client_key` của pamsignal. Server tự động chọn HTTPS thay vì plain HTTP khi các TLS env var được thiết lập.
+
+#### Demo end-to-end cục bộ
+
+```bash
+# 1. Generate a CA + server cert + client cert in the shared dir.
+#    The `./certs/` path here is a symlink to ../shared-certs/, so the
+#    Node example and the Bruno collection pick up the same files.
+(cd ../shared-certs && ./gen-test-certs.sh)
+
+# 2. Configure this example to listen on HTTPS and require a client cert.
+cat >> .env <<'EOF'
+TLS_KEY_PATH=./certs/server.key
+TLS_CERT_PATH=./certs/server.crt
+TLS_CLIENT_CA_PATH=./certs/ca.crt
+TLS_REQUIRE_CLIENT_CERT=true
+EOF
+
+# 3. Start the receiver.
+uv run python src/server.py
+```
+
+Bạn sẽ thấy `🔐 PAMSignal Webhook Receiver listening on https://localhost:3000/webhook/pamsignal (mTLS — client cert required)`.
+
+#### Cấu hình pamsignal
+
+Trong `/etc/pamsignal/pamsignal.conf`:
+
+```ini
+webhook_url = https://localhost:3000/webhook/pamsignal
+webhook_auth_header = Authorization: Bearer your_super_secret_token_here
+webhook_client_cert = /absolute/path/to/certs/client.crt
+webhook_client_key  = /absolute/path/to/certs/client.key
+# Required because the demo CA isn't in the system trust store.
+webhook_ca_bundle   = /absolute/path/to/certs/ca.crt
+```
+
+Reload pamsignal (`sudo systemctl reload pamsignal`) và kích hoạt một event — receiver sẽ ghi log nó. Một request từ bất kỳ client nào không có cert hợp lệ (ví dụ: `curl https://localhost:3000/webhook/pamsignal`) sẽ bị từ chối ngay tại TLS handshake, trước khi đến được Flask.
+
+#### Cấu hình cho môi trường production
+
+Cho các deployment trên môi trường production, hãy thay `./certs/*` bằng các đường dẫn được quản lý bởi cert pipeline của bạn (cert-manager, certbot, `systemd-creds`, internal CA + ACME, v.v.). Bốn env var và các config key `webhook_*` không thay đổi. `gen-test-certs.sh` chỉ dùng cho kiểm thử local/CI — không đưa output của nó lên production.
+
+mTLS kết hợp cộng thêm với `webhook_auth_header` nếu receiver muốn cả hai (mTLS để xác minh danh tính service ở transport layer, Bearer để ủy quyền từng request). Flask middleware trong ví dụ này kiểm tra Bearer token bất kể transport, vì vậy một deployment chỉ dùng mTLS có thể đơn giản để `WEBHOOK_SECRET` trống (hoặc đặt cả hai để tăng cường bảo mật theo chiều sâu).
+
+## 🛠️ Triển khai như Systemd Daemon
+
+Để chạy trên production, bạn nên chạy webhook receiver này như một background service để nó tự động khởi động khi boot và khởi động lại nếu bị crash. Server tích hợp sẵn của Werkzeug phù hợp cho webhook khối lượng thấp, nhưng với tải cao hơn bạn có thể muốn đặt một WSGI server thực (gunicorn, uWSGI) phía trước — điều chỉnh `ExecStart` cho phù hợp.
+
+1. Cài đặt dependencies vào `.venv/` của project:
+   ```bash
+   uv sync --no-dev
+   ```
+
+2. Tạo một systemd service file. Mở `/etc/systemd/system/pamsignal-webhook.service`:
+   ```bash
+   sudo nano /etc/systemd/system/pamsignal-webhook.service
+   ```
+
+3. Dán cấu hình sau đây. Hãy chắc chắn cập nhật `WorkingDirectory` thành đường dẫn thực tế của project và `User` thành user non-root thực tế của bạn:
+
+   ```ini
+   [Unit]
+   Description=PAMSignal Python Webhook Receiver
+   After=network.target
+
+   [Service]
+   Type=simple
+   # Update this to the user you want to run the Python process as
+   User=www-data
+   # Update this to the absolute path of this example directory
+   WorkingDirectory=/opt/pamsignal-python-webhook
+   # Run the server using the venv's Python interpreter
+   ExecStart=/opt/pamsignal-python-webhook/.venv/bin/python src/server.py
+   Restart=on-failure
+   RestartSec=5
+
+   # Load the environment variables from the .env file
+   EnvironmentFile=/opt/pamsignal-python-webhook/.env
+
+   # Security Hardening
+   NoNewPrivileges=yes
+   ProtectSystem=strict
+   ProtectHome=yes
+   PrivateTmp=yes
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+4. Bật và khởi động service:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now pamsignal-webhook
+   sudo systemctl status pamsignal-webhook
+   ```
+
+5. Xem log theo thời gian thực:
+   ```bash
+   journalctl -u pamsignal-webhook -f
+   ```
+
+## 🧪 Kiểm thử thủ công
+
+### Dùng Curl
+
+Bạn có thể mô phỏng một PAMSignal brute-force alert bằng `curl` để kiểm thử Flask server:
+
+```bash
+# Testing with Bearer Token header
+curl -X POST http://localhost:3000/webhook/pamsignal \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer your_super_secret_token_here" \
+     -d '{
+       "event": { "action": "brute_force_detected" },
+       "source": { "ip": "203.0.113.50" },
+       "pamsignal": { "attempts": 12, "window_sec": 300 }
+     }'
+```
+
+Bạn sẽ thấy event được parse và ghi log đẹp trong stream `journalctl` hoặc console Python của bạn.
+
+### Dùng Bruno API Client
+
+Một **Bruno** collection dùng chung nằm tại [`../../../examples/bruno-collection/`](../../../examples/bruno-collection/) và hoạt động với bất kỳ receiver nào triển khai PAMSignal webhook contract — ví dụ Python này và ví dụ Node.js đều đủ điều kiện. Collection đi kèm hai environment:
+
+- **Local** — plain HTTP, chỉ dùng Bearer token
+- **Local-mTLS** — HTTPS với client cert (kết hợp với `TLS_REQUIRE_CLIENT_CERT=true` ở đây)
+
+Xem [`bruno-collection.md`](bruno-collection.md) để biết cách thiết lập cert symlink. Bắt đầu nhanh:
+
+1. Tải [Bruno](https://www.usebruno.com/).
+2. Click **Open Collection** (không phải *Import Collection* — đường dẫn đó dùng cho Postman/OpenAPI JSON) và chọn thư mục `examples/bruno-collection`.
+3. Chọn environment từ dropdown (góc trên bên phải) — `Local` hoặc `Local-mTLS`.
+4. Cập nhật `WEBHOOK_SECRET` của environment đã chọn để khớp với `.env` của bạn và click **Send**.
+
+## ✅ Unit Tests
+
+Project này bao gồm một bộ `pytest` test kiểm tra xác thực (Bearer token), payload validation và đường dẫn mTLS handshake.
+
+Để chạy tests:
+
+```bash
+uv run pytest
+```
+
+Các mTLS test yêu cầu `openssl` phải có trong `PATH` (dùng để generate cert tạm thời trong một thư mục tạm); chúng sẽ tự động bị bỏ qua nếu không tìm thấy.

--- a/docs/vi/examples/shared-certs.md
+++ b/docs/vi/examples/shared-certs.md
@@ -1,0 +1,57 @@
+# Shared mTLS Demo Certs
+
+> 🌐 [English](../../../examples/shared-certs/README.md) · **Tiếng Việt**
+
+Một CA + server cert + client cert tự chứa dùng chung cho cả ba example project để minh họa đường dẫn mTLS của webhook PAMSignal. **Chỉ dùng cho local/demo — không bao giờ dùng các cert này trong production.**
+
+## Nội dung
+
+| File | Đã commit? | Mô tả |
+|---|---|---|
+| `gen-test-certs.sh` | ✅ | Script tạo cert — sinh ra sáu file bên dưới |
+| `README.md` | ✅ | File này |
+| `.gitignore` | ✅ | Bỏ qua các file `*.crt`, `*.key`, `*.csr`, `*.srl` đã tạo |
+| `ca.crt`, `ca.key` | ❌ | Root CA tự ký, dùng bởi cả hai receiver để xác thực client cert |
+| `server.crt`, `server.key` | ❌ | Danh tính server (`CN=localhost`, `SAN=DNS:localhost,IP:127.0.0.1`) dùng bởi cả hai receiver |
+| `client.crt`, `client.key` | ❌ | Danh tính client, được trình bởi `curl` từ PAMSignal, bởi Bruno, và bởi bộ test |
+
+## Cách kết nối
+
+Mỗi consumer tạo symlink đường dẫn `certs/` của nó về đây:
+
+```
+examples/shared-certs/                       ← real files live here
+        ▲
+        ├── examples/python-webhook/certs    (symlink)
+        ├── examples/nodejs-webhook/certs    (symlink)
+        └── examples/bruno-collection/certs  (symlink)
+```
+
+Các receiver tham chiếu `./certs/server.{crt,key}` và `./certs/ca.crt` trong `.env` của chúng; mục Client Certs của Bruno trỏ đến `certs/client.{crt,key}` tương đối với thư mục gốc của collection. Các symlink làm cho cả ba đường dẫn đều phân giải về đây. Chạy `gen-test-certs.sh` một lần là đã cấp cert cho tất cả cùng lúc.
+
+## Cách dùng
+
+```bash
+# From this directory:
+./gen-test-certs.sh
+
+# Or with a custom output dir (rarely needed):
+./gen-test-certs.sh /tmp/some-other-place
+```
+
+Sau khi tạo xong, hãy khởi động lại bất kỳ receiver nào đang chạy — Werkzeug/Express đã nạp cert cũ vào bộ nhớ khi khởi động và sẽ không reload cho đến khi được khởi động lại:
+
+```bash
+# Python:
+cd ../python-webhook && uv run python src/server.py
+# Node:
+cd ../nodejs-webhook && pnpm run dev
+```
+
+## Tại sao dùng một CA dùng chung thay vì mỗi receiver một CA?
+
+Mỗi lần gọi `gen-test-certs.sh` sẽ tạo ra một CA tự ký **độc lập**. Nếu Python và Node mỗi cái chạy script riêng, các CA tạo ra sẽ khác nhau, và một client cert từ cái này sẽ không xác thực được với cái kia. Dùng chung đơn giản hóa việc kiểm thử chéo — tạo một lần, cả hai receiver chấp nhận cùng cert của Bruno (và curl), không cần hoán đổi symlink khi chuyển đổi giữa chúng.
+
+## Cấu hình cho môi trường production
+
+Thay thế nội dung thư mục này bằng các đường dẫn được quản lý bởi cert pipeline của bạn (cert-manager, certbot, internal CA + ACME, `systemd-creds`, v.v.). Bốn env var `TLS_*` và các config key `webhook_*` trong `pamsignal.conf` vẫn như cũ; chỉ có nội dung file thay đổi. Các symlink trong các consumer project có thể giữ nguyên hoặc thay bằng đường dẫn tuyệt đối — tùy theo deployment của bạn.

--- a/docs/vi/grafana-integration.md
+++ b/docs/vi/grafana-integration.md
@@ -1,0 +1,192 @@
+# Grafana Integration — Design
+
+> 🌐 [English](../grafana-integration.md) · **Tiếng Việt**
+
+Tài liệu này là thiết kế đã được chốt cho integration PAMSignal Grafana, được theo dõi trong [issue #25](https://github.com/anhtuank7c/pamsignal/issues/25). Các artifact triển khai nằm dưới `examples/grafana/`.
+
+Mục tiêu: một operator có 5+ host Linux và không có kinh nghiệm Loki nào có thể đi từ `apt install pamsignal` đến một dashboard toàn fleet hoạt động được trong vòng dưới 30 phút.
+
+## Kiến trúc
+
+```mermaid
+graph LR
+    pamsignal["PAMSignal<br/>(per host)"]
+    journald[("systemd-journald<br/>(per host)")]
+    alloy["Grafana Alloy<br/>(per host)"]
+    loki[("Loki")]
+    grafana["Grafana"]
+    operator["🧑‍💻 Operator"]
+
+    pamsignal -- "sd_journal_send<br/>(ECS fields)" --> journald
+    journald -- "SYSLOG_IDENTIFIER=pamsignal" --> alloy
+    alloy -- "Loki push API<br/>(4 labels)" --> loki
+    loki -- "LogQL queries" --> grafana
+    grafana -- "fleet dashboard<br/>+ alerts" --> operator
+
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style alloy fill:#457b9d,stroke:#1d3557,color:#fff
+    style loki fill:#e9c46a,stroke:#f4a261,color:#000
+    style grafana fill:#e76f51,stroke:#d62828,color:#fff
+    style operator fill:#6c757d,stroke:#495057,color:#fff
+```
+
+PAMSignal đã phát ra các trường có cấu trúc căn chỉnh theo ECS qua `sd_journal_send()`. Alloy scrape journald cho `SYSLOG_IDENTIFIER=pamsignal`, promote một tập nhỏ các trường low-cardinality lên thành Loki label, và forward phần còn lại dưới dạng log line được encode JSON. Grafana query Loki qua LogQL.
+
+Không cần thay đổi PAMSignal daemon.
+
+## Schema (những gì PAMSignal đã phát ra)
+
+Mỗi mục được ghi vào journal bởi PAMSignal mang các trường có cấu trúc sau:
+
+| Trường | Giá trị | Cardinality | Dùng làm |
+|---|---|---|---|
+| `SYSLOG_IDENTIFIER` | `pamsignal` | 1 | Alloy filter selector |
+| `EVENT_ACTION` | `session_opened`, `session_closed`, `login_success`, `login_failure`, `brute_force_detected`, `unknown` | 6 | **Loki label** |
+| `EVENT_CATEGORY` | `authentication`, `authentication,session`, `authentication,intrusion_detection` | 3 | log body |
+| `EVENT_KIND` | `event`, `alert` | 2 | log body |
+| `EVENT_OUTCOME` | `success`, `failure`, `unknown` | 3 | log body |
+| `EVENT_SEVERITY` | 3, 4, 5, 8 (numeric) | 4 | log body |
+| `EVENT_MODULE` | `pamsignal` | 1 | log body |
+| `SERVICE_NAME` | `sshd`, `sudo`, `su`, `login`, `other` | 5 | **Loki label** |
+| `USER_NAME` | username | cao | log body |
+| `USER_TARGET_NAME` | sudo/su target | cao | log body |
+| `SOURCE_IP` | địa chỉ từ xa | cao | log body |
+| `SOURCE_PORT` | cổng từ xa | cao | log body |
+| `PROCESS_PID` | PID của auth process | cao | log body |
+| `HOST_HOSTNAME` | hostname (cũng là `_HOSTNAME` native của journald) | trung bình | (dư thừa) |
+
+Nguồn sự thật: `src/journal_watch.c` (`emit_brute_force_alert`, `ps_log_event`) và `src/utils.c` (`ps_event_action_str`, `ps_service_str`, `ps_event_outcome_str`).
+
+## Kế hoạch label cardinality
+
+Loki index label — label high-cardinality làm index bùng nổ. Kế hoạch giữ cardinality bounded.
+
+**Được promote lên Loki label (dùng trong mọi selector):**
+
+- `app="pamsignal"` — tĩnh, được đặt bởi Alloy
+- `host` ← `__journal__hostname` — một per host (bounded bởi kích thước fleet)
+- `service` ← `__journal_service_name` — 5 giá trị
+- `event_action` ← `__journal_event_action` — 6 giá trị
+
+Tổng stream: `~5 × 6 × fleet_size ≈ 30 × N`. An toàn cho đến hàng nghìn host.
+
+**Ở lại trong log body (được parse lúc query qua `| json`):**
+
+- `SOURCE_IP`, `USER_NAME`, `USER_TARGET_NAME`, `SOURCE_PORT`, `PROCESS_PID`, `EVENT_SEVERITY`, `EVENT_OUTCOME`, `EVENT_KIND`
+
+`event_outcome` và `event_kind` có thể suy ra từ `event_action` — không có lý do gì để index chúng. Source IP và username là high-cardinality; query chúng theo nhu cầu là đánh đổi đúng.
+
+## Layout dashboard
+
+Ba row, từ trên xuống dưới:
+
+### Row 1 — Fleet pulse (5 stat panel)
+
+Cái nhìn "chiều thứ Sáu." Mỗi panel là một con số, màu sắc theo mã.
+
+1. **Hosts reporting (1h qua)** — liveness của fleet
+2. **Đăng nhập thành công** (phạm vi)
+3. **Đăng nhập thất bại** (phạm vi)
+4. **Cảnh báo brute-force** (phạm vi) — đỏ nếu > 0
+5. **Privilege escalation** (sudo/su `session_opened`, phạm vi)
+
+### Row 2 — Trends (3 time-series)
+
+6. **Số lần login/phút** — xếp chồng theo `event_outcome` (success vs failure)
+7. **Phát hiện brute-force/phút** — xếp chồng theo `service`
+8. **Events/phút mỗi host** — stacked area, top-10 host; phát hiện host ồn ào
+
+### Row 3 — Drill-down (4 table + 1 logs panel)
+
+9. **Top 10 source IP theo số lần login thất bại** (`SOURCE_IP` đã parse)
+10. **Top 10 username bị tấn công** (`USER_NAME` đã parse)
+11. **Cảnh báo brute-force gần đây** — thời gian, ip-or-actor, số lần thử, window, service, host
+12. **Đăng nhập root thành công gần đây** — `event_action="login_success"` AND `USER_NAME="root"`
+13. **Live log stream** — sự kiện pamsignal được lọc theo biến dashboard
+
+### Variables (multi-select, mặc định "All")
+
+- `$host` (từ label `host`)
+- `$service` (từ label `service`)
+- `$action` (từ label `event_action`)
+
+### Phạm vi thời gian mặc định
+
+6h qua. Tùy chọn nhanh: 1h / 6h / 24h / 7d / 30d.
+
+## Mẫu LogQL query
+
+Scheme bốn label giữ cho query dễ đọc:
+
+```logql
+# Failed-login rate
+count_over_time({app="pamsignal", event_action="login_failure",
+                 host=~"$host", service=~"$service"}[1m])
+
+# Brute-force rate by service
+sum by (service) (
+  count_over_time({app="pamsignal", event_action="brute_force_detected"}[5m])
+)
+
+# Top source IPs (parsed from JSON body)
+topk(10,
+  sum by (source_ip) (
+    count_over_time(
+      {app="pamsignal", event_action="login_failure"}
+      | json source_ip="SOURCE_IP"
+      [$__range]
+    )
+  )
+)
+
+# Successful root logins
+{app="pamsignal", event_action="login_success", service="sshd"}
+  | json user_name="USER_NAME"
+  | user_name="root"
+```
+
+## Alerts
+
+Được ship trong `examples/grafana/alerts.yaml` dưới dạng Grafana-native rule:
+
+| # | Rule | Severity | Lý do |
+|---|---|---|---|
+| 1 | Bất kỳ `event_action="brute_force_detected"` nào | critical | PAMSignal đã xác thực ngưỡng; alert đáng tin cậy |
+| 2 | `event_action="login_success"` AND `USER_NAME="root"` trên `service="sshd"` | high | SSH root trực tiếp là sự kiện "bạn nên quan tâm" kinh điển |
+| 3 | ≥10 `login_failure` từ một `SOURCE_IP` trong 5 phút | high | Safety net nếu operator đã điều chỉnh `fail_threshold` rất cao |
+| 4 | Host ngừng báo cáo > 10 phút | medium | Heartbeat — daemon chết hoặc host offline |
+
+Đăng nhập ngoài giờ là theo chính sách cụ thể. Ngoài phạm vi của v1.
+
+## Đường dùng thử (docker-compose)
+
+PAMSignal cần systemd + journald, điều này khó trong container. Stack thử nghiệm tránh điều này bằng cách bao gồm một **synthetic event producer** (container Python nhỏ) đẩy các log line có hình dạng pamsignal trực tiếp đến Loki qua HTTP push API. Điều này đủ để demo dashboard và chạy CI.
+
+Đường "PAMSignal thực sự" được ghi lại trong `examples/grafana/README.md` và dùng Alloy được cài trên host.
+
+## Layout deliverable
+
+```
+examples/grafana/
+├── README.md              — integration guide (thân thiện với người mới dùng Loki)
+├── alloy.river            — Alloy config: journald → Loki
+├── dashboards/
+│   └── pamsignal-v1.json  — dashboard
+├── alerts.yaml            — Grafana alert rule
+├── docker-compose.yml     — Loki + Alloy + Grafana try-it stack
+├── synthetic/             — synthetic event producer (thử nghiệm & CI)
+│   ├── Dockerfile
+│   └── produce.py
+└── verify.sh              — kiểm tra health integration một lệnh
+```
+
+## Tiêu chí thành công
+
+Được sao chép từ issue để theo dõi thuận tiện:
+
+1. Operator có 5+ Linux VPS và không có kinh nghiệm Loki nào đến được dashboard hoạt động trong vòng dưới 30 phút theo hướng dẫn.
+2. Dashboard trả lời "điều gì đang xảy ra với auth trên fleet của tôi ngay bây giờ?" chỉ cần nhìn qua.
+3. Listing grafana.com đạt 1k+ lượt tải xuống trong 3 tháng đầu.
+4. Ít nhất một contributor bên ngoài mở PR cải thiện integration.
+5. CI chứng minh integration vẫn hoạt động trên mỗi bản cập nhật Grafana / Loki / Alloy.

--- a/docs/vi/notes/meson-build-system.md
+++ b/docs/vi/notes/meson-build-system.md
@@ -1,0 +1,76 @@
+# Meson & Ninja: Công Cụ Build
+
+> 🌐 [English](../../notes/meson-build-system.md) · **Tiếng Việt**
+
+- **Trạng thái**: Hoàn thành
+- **Ngày bắt đầu**: 20/02/2026
+- **Ngày hoàn thành**: 20/02/2026
+
+Meson và Ninja phối hợp với nhau để thay thế CMake và Make. Chúng được thiết kế để cực kỳ nhanh và thân thiện với người dùng.
+
+* **Meson** tương đương với **CMake**: Đọc file cấu hình (`meson.build`) và sinh ra các file build.
+* **Ninja** tương đương với **Make**: Đọc các file build đã được sinh ra và thực sự biên dịch mã nguồn.
+
+## Bảng Tương Đương Các File
+
+| CMake System           | Meson System          | Mục đích                                            |
+|------------------------|-----------------------|-----------------------------------------------------|
+| `CMakeLists.txt`       | `meson.build`         | Định nghĩa project, targets và dependencies         |
+| `cmake -S . -B build`  | `meson setup build`   | Sinh ra các file build trong một thư mục            |
+| `make`                 | `ninja`               | Thực sự biên dịch mã nguồn                          |
+| `build/Makefile`       | `build/build.ninja`   | Các file được sinh ra để dùng khi biên dịch         |
+
+## Cách Sử Dụng Meson & Ninja
+
+Đây là quy trình chuẩn bạn sẽ dùng hàng ngày.
+
+### 1. Cấu hình project (Chỉ làm một lần)
+Lệnh này yêu cầu Meson đọc `meson.build` và tạo thư mục build.
+
+```bash
+# Cú pháp chung: meson setup <build-directory>
+meson setup build
+```
+
+*Lưu ý: Bạn có thể truyền thêm các tùy chọn ở đây, như `--buildtype=release` hoặc `--buildtype=debug`.*
+
+### 2. Build project (Làm mỗi khi thay đổi mã nguồn)
+Yêu cầu Meson biên dịch các thay đổi. Nó sẽ tự động gọi Ninja bên dưới.
+
+```bash
+# Cú pháp chung: meson compile -C <build-directory>
+meson compile -C build 
+```
+
+*(Hoặc bạn có thể `cd` vào thư mục build và gõ `ninja`)*
+
+### 3. Dọn dẹp project
+Với Meson, bạn thường không cần lệnh `clean`. Vì nó rất nhanh, bạn chỉ cần xóa thư mục build và cấu hình lại nếu mọi thứ trở nên lộn xộn.
+
+```bash
+rm -rf build && meson setup build
+```
+
+## Tại Sao Dùng Meson Thay Vì CMake?
+
+1. **Cú pháp**: `meson.build` sử dụng cú pháp sạch, giống Python, dễ đọc và viết hơn `CMakeLists.txt` nhiều.
+2. **Tốc độ**: Sinh ra các file build cực kỳ nhanh.
+3. **Ninja theo mặc định**: Make nổi tiếng là chậm với các project lớn. Ninja được thiết kế để nhanh nhất có thể, và Meson sử dụng nó theo mặc định.
+4. **Quản lý Dependencies**: Tìm và sử dụng các thư viện ngoài (như `systemd` qua `pkg-config`) thường đơn giản hơn và ít verbose hơn trong Meson.
+
+## Tại Sao Dùng Meson Thay Vì Lệnh GCC Trực Tiếp?
+
+Nếu bạn biên dịch project này thủ công bằng `gcc`, lệnh sẽ trông như thế này:
+
+```bash
+gcc src/init.c src/journal_watch.c src/main.c src/utils.c \
+    -Iinclude -o build/pamsignal \
+    $(pkg-config --cflags --libs libsystemd) \
+    -Wall -Wextra -Wshadow -std=gnu17 -O2
+```
+
+Khi project phát triển, việc quản lý một lệnh duy nhất như thế này trở nên cực kỳ khó khăn:
+
+1. **Incremental Builds**: Lệnh `gcc` trực tiếp biên dịch lại **mọi** file nguồn mỗi lần chạy, kể cả khi bạn chỉ thay đổi một dòng trong một file. Meson (thông qua Ninja) đủ thông minh để phát hiện chính xác những file nào đã thay đổi và chỉ biên dịch lại những file đó, giúp quy trình làm việc của bạn nhanh hơn đáng kể.
+2. **Quản lý Độ Phức Tạp**: Thêm thư mục mới, tính năng mới, hoặc chuẩn hóa các compiler flags cho nhiều lập trình viên sẽ tạo ra một lệnh `gcc` khổng lồ, dễ xảy ra lỗi. `meson.build` tổ chức điều này một cách logic từng dòng một.
+3. **Cấu hình Build**: Meson dễ dàng chuyển đổi giữa các profile (như Debug cho môi trường phát triển hay Release cho bản production) chỉ bằng cách truyền một flag (`meson setup build --buildtype=debug`). Với GCC trực tiếp, bạn phải tự thay `-O2` thành `-g -O0` và theo dõi các dependency thủ công mỗi lần.

--- a/docs/vi/notes/project-initialization.md
+++ b/docs/vi/notes/project-initialization.md
@@ -1,0 +1,66 @@
+# Bước 1 - Khởi Tạo (Project Initialization)
+
+> 🌐 [English](../../notes/project-initialization.md) · **Tiếng Việt**
+
+- **Trạng thái**: Hoàn thành
+- **Ngày bắt đầu**: 26/12/2025
+- **Ngày hoàn thành**: 26/12/2025
+- **Ngày cập nhật**: 20/02/2026
+
+## 1. Mục Tiêu
+
+Thiết lập nền tảng cho project **PAMSignal**. Đảm bảo mã nguồn được tổ chức khoa học, dễ mở rộng, và có quy trình build tự động với hiệu năng được tối ưu.
+
+## 2. Yêu Cầu
+
+**Hệ Điều Hành**
+
+Vì project tập trung vào Linux và yêu cầu thư viện **libsystemd**, để chạy project này bạn cần sử dụng hệ điều hành Linux, chẳng hạn Ubuntu hoặc bất kỳ distro nào khác.
+
+**Tại sao chọn Meson build system?** [xem chi tiết tại đây](./phase-1-meson_guide.md)
+
+**Tài liệu Meson** [xem chi tiết tại đây](https://mesonbuild.com/Quick-guide.html)
+
+**Dependencies**
+
+```bash
+sudo apt update
+sudo apt install libsystemd-dev pkg-config build-essential meson ninja-build
+```
+
+Sau khi cài đặt, bạn có thể clone project và chạy các lệnh `meson` và `ninja`. Kết quả đầu ra sẽ là file thực thi `pamsignal` nằm trong `build/`.
+
+```bash
+git clone git@github.com:anhtuank7c/pamsignal.git
+cd pamsignal
+meson setup build
+meson compile -C build
+```
+
+## 3. Cấu Trúc Thư Mục
+
+```
+pamsignal
+    src/            Chứa mã nguồn thực thi (.c)
+    include/        Chứa các header file (.h) để quản lý interface.
+    meson.build     Quản lý quy trình build.
+    docs/           Quản lý tài liệu
+```
+
+## 4. Tối Ưu Hóa Biên Dịch Với Meson
+
+Trình biên dịch C có nhiều tùy chọn liên quan đến tối ưu hóa mã máy [xem chi tiết tại đây](https://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Optimize-Options.html)
+
+Theo mặc định trong `meson.build`, tôi đã chỉ định `'buildtype=release'` làm tùy chọn mặc định. Trong Meson, kiểu build `release` tự động áp dụng mức tối ưu hóa `-O3` và loại bỏ các debug symbols.
+
+**Tại sao chọn chế độ Release?**
+
+Đây là kiểu build tối ưu hóa giúp trình biên dịch sắp xếp lại các lệnh máy, loại bỏ mã dư thừa, và tăng tốc độ xử lý log đáng kể so với các bản debug build.
+
+## 5. Kết Quả
+
+- [x] Khởi tạo cấu trúc thư mục thành công.
+
+- [x] Cấu hình Meson hoạt động tốt, phát hiện thư viện `libsystemd` chính xác.
+
+- [x] Biên dịch thành công file thực thi đầu tiên (Sanity Check).

--- a/docs/vi/notes/systemd-journal.md
+++ b/docs/vi/notes/systemd-journal.md
@@ -1,0 +1,608 @@
+# Journal Subscriber
+
+> 🌐 [English](../../notes/systemd-journal.md) · **Tiếng Việt**
+
+- **Trạng thái**: Hoàn thành
+- **Ngày bắt đầu**: 27/12/2025
+- **Ngày hoàn thành**: 17/02/2026
+- **Ngày cập nhật**: 20/02/2026
+
+## 1. Mục Tiêu
+
+- **Event-driven**: Thay thế cách quét file log truyền thống bằng cách đăng ký nhận sự kiện từ `libsystemd`, cho phép PAMSignal phản ứng ngay lập tức khi có log mới mà không lãng phí tài nguyên trong thời gian rảnh.
+- **Thời gian thực**: Tận dụng hàm `sd_journal_wait()` để đạt độ trễ `~0s` từ khi hệ thống ghi nhận một phiên đăng nhập đến khi PAMSignal bắt đầu xử lý dữ liệu.
+- **Dữ liệu có cấu trúc**: Khai thác định dạng nhị phân của Journal để truy xuất chính xác các trường metadata như `MESSAGE`, `_PID`, `_UID`.
+
+## 2. Tổng Quan Kiến Trúc Linux
+
+Để hiểu PAMSignal hoạt động như thế nào, chúng ta cần hiểu kiến trúc phân lớp của một hệ thống Linux:
+
+```mermaid
+graph TD
+    subgraph userspace ["User Space Applications"]
+        apps["SSH clients · login · sudo · web apps · PAMSignal"]
+    end
+
+    subgraph libs ["System Libraries & Services"]
+        pam["PAM<br/>(libpam.so)"]
+        systemd["systemd<br/>(libsystemd)"]
+        glibc["glibc"]
+    end
+
+    subgraph kernel ["Linux Kernel"]
+        security["Security<br/>Subsystem"]
+        process["Process<br/>Management"]
+        logging["Logging<br/>(printk)"]
+    end
+
+    hardware["Hardware<br/>CPU · Memory · Disk · Network"]
+
+    apps -- "system calls" --> libs
+    libs --> kernel
+    kernel --> hardware
+
+    style apps fill:#6c757d,stroke:#495057,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style systemd fill:#264653,stroke:#1d3557,color:#fff
+    style glibc fill:#577590,stroke:#1d3557,color:#fff
+    style security fill:#4a4e69,stroke:#22223b,color:#fff
+    style process fill:#4a4e69,stroke:#22223b,color:#fff
+    style logging fill:#4a4e69,stroke:#22223b,color:#fff
+    style hardware fill:#22223b,stroke:#000,color:#fff
+```
+
+**Các Lớp Chính:**
+
+1. **Lớp Hardware**: Tài nguyên vật lý (CPU, RAM, lưu trữ, giao diện mạng)
+2. **Kernel Space**: Kernel Linux quản lý phần cứng, tiến trình, bộ nhớ và bảo mật
+3. **System Libraries**: Các thư viện dùng chung như PAM, systemd, glibc cung cấp API cho các ứng dụng
+4. **User Space**: Các ứng dụng và dịch vụ mà người dùng tương tác
+
+**Luồng Xác Thực trong Linux:**
+
+Khi người dùng cố gắng đăng nhập (qua SSH, console, hoặc GUI), quá trình diễn ra như sau:
+
+```mermaid
+graph TD
+    login["User login attempt"]
+    app["Login App<br/>sshd · login · gdm"]
+    pam["PAM (libpam)<br/>checks /etc/pam.d/<br/>executes modules in order"]
+    journald[("systemd-journald<br/>receives log entry<br/>stores in binary journal")]
+    pamsignal["PAMSignal (subscriber)<br/>reads via libsystemd<br/>processes & sends alerts"]
+
+    login --> app
+    app -- "calls PAM API" --> pam
+    pam -- "logs to syslog/journal" --> journald
+    journald -- "event notification" --> pamsignal
+
+    style login fill:#6c757d,stroke:#495057,color:#fff
+    style app fill:#577590,stroke:#1d3557,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+```
+
+## 3. PAM (Pluggable Authentication Module) Là Gì?
+
+**PAM** là một framework xác thực linh hoạt được hầu hết các distro Linux sử dụng để xử lý các tác vụ xác thực theo cách module hóa, có thể cấu hình.
+
+### 3.1 Tại Sao PAM Tồn Tại
+
+Trước khi có PAM, mỗi ứng dụng (login, ssh, sudo, v.v.) phải tự triển khai logic xác thực riêng. Điều này dẫn đến:
+- Trùng lặp mã nguồn giữa các ứng dụng
+- Chính sách bảo mật không nhất quán
+- Khó cập nhật cơ chế xác thực trên toàn hệ thống
+
+PAM giải quyết vấn đề này bằng cách cung cấp một **hệ thống xác thực tập trung, có thể cắm module**.
+
+### 3.2 PAM Hoạt Động Như Thế Nào
+
+**Các File Cấu Hình**: Nằm trong `/etc/pam.d/`, mỗi dịch vụ có cấu hình PAM riêng:
+
+```bash
+/etc/pam.d/
+├── sshd          # Quy tắc xác thực SSH
+├── login         # Quy tắc đăng nhập console
+├── sudo          # Quy tắc xác thực sudo
+├── common-auth   # Quy tắc xác thực dùng chung
+└── ...
+```
+
+**Ví Dụ Cấu Hình PAM** (`/etc/pam.d/sshd`):
+
+```
+# PAM configuration for SSH daemon
+auth       required     pam_unix.so        # Check password
+auth       required     pam_env.so         # Set environment
+account    required     pam_unix.so        # Check account validity
+session    required     pam_systemd.so     # Register session with systemd
+session    required     pam_unix.so        # Setup session
+```
+
+**Các Loại Module PAM:**
+
+1. **auth**: Xác minh danh tính người dùng (mật khẩu, sinh trắc học, 2FA)
+2. **account**: Kiểm tra tính hợp lệ của tài khoản (chưa hết hạn, chưa bị khóa)
+3. **session**: Thiết lập/dọn dẹp phiên người dùng (mount home dir, ghi log phiên)
+4. **password**: Cập nhật token xác thực (đổi mật khẩu)
+
+**Các Control Flag:**
+
+- `required`: Phải thành công, nhưng tiếp tục kiểm tra các module khác
+- `requisite`: Phải thành công, dừng ngay nếu thất bại
+- `sufficient`: Thành công là đủ, bỏ qua các module còn lại
+- `optional`: Kết quả bị bỏ qua trừ khi đây là module duy nhất
+
+### 3.3 PAM và Ghi Log Xác Thực
+
+Khi PAM xác thực người dùng, nó tạo ra các thông điệp log được gửi đến system logger:
+
+**Truyền thống (rsyslog):**
+```
+Feb 17 22:30:15 server sshd[12345]: Accepted password for user from 192.168.1.100 port 54321 ssh2
+Feb 17 22:30:15 server sshd[12345]: pam_unix(sshd:session): session opened for user by (uid=0)
+```
+
+**Hiện đại (systemd-journald):**
+```json
+{
+  "MESSAGE": "pam_unix(sshd:session): session opened for user by (uid=0)",
+  "_PID": "12345",
+  "_UID": "0",
+  "_SYSTEMD_UNIT": "sshd.service",
+  "_HOSTNAME": "server",
+  "_SOURCE_REALTIME_TIMESTAMP": "1708186215000000",
+  "SYSLOG_IDENTIFIER": "sshd"
+}
+```
+
+**Đây chính là lúc PAMSignal phát huy tác dụng**: Nó theo dõi các sự kiện xác thực PAM này để phát hiện và cảnh báo về các phiên đăng nhập.
+
+## 4. So Sánh Giải Pháp: Quét auth.log vs systemd-journald
+
+### 4.1 Cách Tiếp Cận Cũ: Quét auth.log Định Kỳ
+
+**Kiến trúc:**
+
+```
+┌──────────────────────────────────────────┐
+│         PAMSignal (Old Version)          │
+│                                          │
+│  while (true) {                          │
+│    sleep(500ms);  ← Polling interval     │
+│    read("/var/log/auth.log");            │
+│    parse_new_lines();                    │
+│    if (login_detected) {                 │
+│      send_alert();                       │
+│    }                                     │
+│  }                                       │
+└──────────────────────────────────────────┘
+                    │
+                    ▼
+         ┌──────────────────┐
+         │ /var/log/auth.log│ (Plain text file)
+         │ (rsyslog writes) │
+         └──────────────────┘
+```
+
+**Các Vấn Đề:**
+
+1. **Sử Dụng Tài Nguyên Kém Hiệu Quả**
+   - Thức dậy mỗi 500ms kể cả khi không có đăng nhập nào
+   - Trên một server thông thường: ~172.800 lần thức dậy không cần thiết mỗi ngày
+   - Lãng phí chu kỳ CPU và pin (trên laptop)
+
+2. **Phân Tích Cú Pháp Dễ Vỡ**
+   - Định dạng log khác nhau giữa các distro:
+     ```
+     # Ubuntu/Debian
+     Feb 17 22:30:15 server sshd[12345]: Accepted password for user from 192.168.1.100
+     
+     # CentOS/RHEL
+     2026-02-17T22:30:15.123456+07:00 server sshd[12345]: Accepted password for user from 192.168.1.100
+     
+     # Arch Linux
+     [2026-02-17 22:30:15] server sshd[12345]: Accepted password for user from 192.168.1.100
+     ```
+   - Yêu cầu các pattern regex phức tạp, dễ hỏng khi nâng cấp OS
+   - Khó trích xuất metadata (PID, UID, hostname)
+
+3. **Lỗ Hổng Bảo Mật**
+   - **Race Condition**: Nếu kẻ tấn công xóa log trong vòng 500ms, PAMSignal sẽ bỏ sót sự kiện
+   - **Giả mạo Log**: Các file plain text dễ bị chỉnh sửa/xóa
+   - **Không Có Kiểm Tra Tính Toàn Vẹn**: Không thể phát hiện nếu log đã bị thay đổi
+
+4. **Độ Trễ**
+   - Độ trễ tối thiểu 500ms (trung bình 250ms)
+   - Không chấp nhận được cho giám sát bảo mật thời gian thực
+
+### 4.2 Cách Tiếp Cận Hiện Tại: Đăng Ký Sự Kiện systemd-journald
+
+**Kiến trúc:**
+
+```
+┌──────────────────────────────────────────┐
+│         PAMSignal (New Version)          │
+│                                          │
+│  sd_journal_open(&j);                    │
+│  sd_journal_wait(j, -1);  ← Blocking     │
+│                                          │
+│  // Wakes ONLY when event occurs         │
+│  while (sd_journal_next(j) > 0) {        │
+│    get_data(j, "MESSAGE");               │
+│    get_data(j, "_PID");                  │
+│    send_alert();                         │
+│  }                                       │
+└──────────────────────────────────────────┘
+                    ▲
+                    │ Event notification
+         ┌──────────┴──────────┐
+         │  systemd-journald   │
+         │  (Binary journal)   │
+         │  /var/log/journal/  │
+         └─────────────────────┘
+```
+
+**Ưu Điểm:**
+
+1. **Hiệu Quả Theo Mô Hình Event-Driven**
+   - Sử dụng CPU bằng 0 khi rảnh (blocking wait)
+   - Thức dậy CHỈ khi có sự kiện xác thực xảy ra
+   - Giảm ~99,9% số lần thức dậy so với polling
+
+2. **Truy Cập Dữ Liệu Có Cấu Trúc**
+   - Không cần phân tích cú pháp, truy cập trực tiếp theo trường:
+     ```c
+     sd_journal_get_data(j, "MESSAGE", &data, &length);
+     sd_journal_get_data(j, "_PID", &data, &length);
+     sd_journal_get_data(j, "_UID", &data, &length);
+     ```
+   - Định dạng nhất quán trên tất cả các distro
+   - Metadata phong phú tự động có sẵn
+
+3. **Hardening Bảo Mật**
+   - **Thông Báo Tức Thì**: Độ trễ ~0ms, không có cửa sổ race condition
+   - **Chống Giả Mạo**: Forward Secure Sealing (FSS) ngăn chặn việc chỉnh sửa log bằng mật mã
+   - **Kiểm Tra Tính Toàn Vẹn**: Có thể phát hiện nếu log đã bị thay đổi
+   - **Ghi Log Ở Cấp Kernel**: Khó bị kẻ tấn công vượt qua hơn
+
+4. **Hiệu Năng Thời Gian Thực**
+   - Độ trễ dưới mili giây từ sự kiện đến xử lý
+   - Phù hợp cho giám sát bảo mật quan trọng
+
+### 4.3 Bảng So Sánh Chi Tiết
+
+| Khía cạnh | Quét auth.log | systemd-journald |
+|--------|------------------|------------------|
+| **CPU Usage (Idle)** | Liên tục (polling mỗi 500ms) | Bằng 0 (event-driven blocking) |
+| **Độ trễ** | 0-500ms (trung bình 250ms) | <1ms (thông báo tức thì) |
+| **Định dạng dữ liệu** | Văn bản không có cấu trúc | Nhị phân có cấu trúc (key-value) |
+| **Độ phức tạp phân tích** | Cao (regex, khác nhau theo distro) | Không có (truy cập trực tiếp theo trường) |
+| **Trích xuất Metadata** | Phân tích thủ công (dễ sai) | Tự động (PID, UID, timestamp, v.v.) |
+| **Chống Giả Mạo** | Không có (plain text file) | Cao (niêm phong bằng mật mã) |
+| **Nguy cơ Race Condition** | Có (cửa sổ 500ms) | Không (thông báo tức thì) |
+| **Hỗ Trợ Đa Distro** | Dễ vỡ (khác biệt định dạng) | Vững chắc (API được chuẩn hóa) |
+| **Hiệu quả tài nguyên** | ~172.800 lần thức dậy/ngày | ~10-100 lần thức dậy/ngày (thông thường) |
+| **Độ phức tạp triển khai** | Cao (logic phân tích cú pháp) | Thấp (libsystemd API) |
+
+**Kết luận**: Cách tiếp cận systemd-journald vượt trội hơn ở mọi khía cạnh có thể đo lường: hiệu năng, bảo mật, độ tin cậy và khả năng bảo trì.
+
+## 5. PAMSignal Hoạt Động Như Thế Nào Bên Dưới
+
+### 5.1 Kiến Trúc Tổng Quan
+
+```mermaid
+graph TD
+    login["User Login Event<br/>SSH · console · GUI · sudo · su"]
+    pam["PAM Authentication<br/>1. verify credentials (password / key / 2FA)<br/>2. check account validity<br/>3. setup session<br/>4. log auth event"]
+    journald[("systemd-journald (log collector)<br/>receives from PAM · adds metadata<br/>writes binary journal · notifies subscribers")]
+    pamsignal["PAMSignal subscriber<br/>1. sd_journal_wait()<br/>2. extract auth data<br/>3. determine login type<br/>4. gather context<br/>5. send notification"]
+    notify["User notification<br/>🔐 SSH login: user@192.168.1.100 → server"]
+
+    login --> pam
+    pam --> journald
+    journald -- "event notification" --> pamsignal
+    pamsignal -- "Telegram · Slack · Webhook · Email" --> notify
+
+    style login fill:#6c757d,stroke:#495057,color:#fff
+    style pam fill:#577590,stroke:#1d3557,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style pamsignal fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style notify fill:#e9c46a,stroke:#f4a261,color:#000
+```
+
+### 5.2 Quy Trình Nội Bộ của PAMSignal
+
+**Bước 1: Khởi Tạo**
+
+```c
+// Open the systemd journal
+sd_journal *journal;
+sd_journal_open(&journal, SD_JOURNAL_LOCAL_ONLY);
+
+// Seek to the end (only monitor new events)
+sd_journal_seek_tail(journal);
+sd_journal_previous(journal); // Move to last entry
+
+// Add filters for authentication events
+sd_journal_add_match(journal, "_SYSTEMD_UNIT=sshd.service", 0);
+sd_journal_add_match(journal, "SYSLOG_IDENTIFIER=sshd", 0);
+// ... add more filters for login, sudo, etc.
+```
+
+**Bước 2: Vòng Lặp Sự Kiện (Blocking Wait)**
+
+```c
+while (1) {
+    // Block until new journal entries arrive
+    // This is the KEY difference from polling
+    int ret = sd_journal_wait(journal, (uint64_t) -1);
+    
+    if (ret < 0) {
+        // Handle error
+        continue;
+    }
+    
+    // Process all new entries
+    while (sd_journal_next(journal) > 0) {
+        process_journal_entry(journal);
+    }
+}
+```
+
+**Bước 3: Trích Xuất Dữ Liệu Xác Thực**
+
+```c
+void process_journal_entry(sd_journal *j) {
+    const void *data;
+    size_t length;
+    
+    // Extract message
+    sd_journal_get_data(j, "MESSAGE", &data, &length);
+    char *message = extract_value(data, length);
+    
+    // Check if it's a successful login
+    if (!is_successful_login(message)) {
+        return;
+    }
+    
+    // Extract metadata
+    sd_journal_get_data(j, "_PID", &data, &length);
+    int pid = parse_int(data, length);
+    
+    sd_journal_get_data(j, "_UID", &data, &length);
+    int uid = parse_int(data, length);
+    
+    sd_journal_get_data(j, "_HOSTNAME", &data, &length);
+    char *hostname = extract_value(data, length);
+    
+    uint64_t timestamp;
+    sd_journal_get_realtime_usec(j, &timestamp);
+    
+    // Parse login details from message
+    LoginEvent event = parse_login_message(message);
+    event.pid = pid;
+    event.uid = uid;
+    event.hostname = hostname;
+    event.timestamp = timestamp;
+    
+    // Send notification
+    send_notification(&event);
+}
+```
+
+**Bước 4: Gửi Thông Báo**
+
+```c
+void send_notification(LoginEvent *event) {
+    // Format message
+    char message[1024];
+    snprintf(message, sizeof(message),
+        "🔐 %s login\n"
+        "👤 User: %s\n"
+        "🌐 From: %s\n"
+        "🖥️  Server: %s\n"
+        "⏰ Time: %s",
+        event->type,      // "SSH", "Console", "Sudo"
+        event->username,
+        event->source_ip,
+        event->hostname,
+        format_timestamp(event->timestamp)
+    );
+    
+    // Send via configured channels
+    if (config.telegram_enabled) {
+        send_telegram(message);
+    }
+    if (config.email_enabled) {
+        send_email(message);
+    }
+    if (config.webhook_enabled) {
+        send_webhook(message);
+    }
+}
+```
+
+### 5.3 Các Quyết Định Thiết Kế Chính
+
+**Tại Sao Event-Driven?**
+- **Hiệu quả**: Không lãng phí chu kỳ CPU trong thời gian rảnh
+- **Thời gian thực**: Phản ứng tức thì với các sự kiện bảo mật
+- **Khả năng mở rộng**: Có thể xử lý các hệ thống xác thực lưu lượng cao
+
+**Tại Sao libsystemd?**
+- **Chuẩn hóa**: Hoạt động trên tất cả các distro dựa trên systemd (Ubuntu, Debian, Fedora, Arch, v.v.)
+- **Độ tin cậy**: Được duy trì bởi dự án systemd, đã được thử nghiệm thực tế
+- **Hiệu năng**: Thư viện C được tối ưu hóa với overhead tối thiểu
+
+**Tại Sao Binary Journal?**
+- **Dữ liệu có cấu trúc**: Không có lỗi phân tích cú pháp, truy cập trực tiếp theo trường
+- **Bảo mật**: Chống giả mạo với niêm phong bằng mật mã
+- **Hiệu quả**: Lưu trữ có index để truy vấn nhanh
+
+**Khi PAMSignal Chạy:**
+- Là một systemd service (được quản lý bởi chính systemd)
+- Khởi động cùng hệ thống, chạy liên tục
+- Tự động khởi động lại khi gặp lỗi
+- Footprint tài nguyên tối thiểu (~1-2MB RAM, 0% CPU khi rảnh)
+
+## 6. Hiểu Về systemd và journal
+
+Trước đây, tôi có một ý tưởng cực kỳ đơn giản: quét file `/var/log/auth.log` rồi phân tích chuỗi để trích xuất thông tin phiên đăng nhập. Dù điều này có thể chứng minh khái niệm "cảnh báo đăng nhập" là khả thi, nhưng về mặt hiệu năng, ổn định và độ tin cậy, nó không đủ vững chắc.
+
+**Cụ thể:**
+
+- Xử lý từng dòng log gặp nhiều khó khăn vì định dạng thời gian và các pattern thông điệp khác nhau đáng kể giữa các phiên bản OS, dẫn đến việc trích xuất thông tin không đáng tin cậy.
+
+- Polling định kỳ mỗi `500ms` lãng phí tài nguyên. Trong một ngày thông thường, không có nhiều phiên đăng nhập thành công vào hệ thống, vì vậy cách tiếp cận này kém hiệu quả.
+- Nếu một hacker xâm nhập vào hệ thống và xóa dấu vết trong file auth.log trong vòng 500ms, hệ thống sẽ hoàn toàn không hay biết.
+
+### 6.1 systemd Là Gì?
+
+**systemd** là một system và service manager hiện đại cho hệ điều hành Linux, được phát hành vào năm 2010 bởi Lennart Poettering. Nó đã trở thành tiêu chuẩn de facto init system cho hầu hết các distro Linux lớn, thay thế SysV (System V - phiên bản lớn thứ năm của Unix do AT&T Bell Labs phát triển vào những năm 1980, phát hành năm 1983) init truyền thống.
+
+**SysV init (Truyền thống):**
+
+- Sử dụng shell scripts trong `/etc/init.d/` để khởi động/dừng dịch vụ
+- Khởi động tuần tự (các dịch vụ khởi động lần lượt từng cái)
+- Đơn giản nhưng thời gian boot chậm
+- Quản lý dependency hạn chế
+- Được sử dụng từ những năm 1980 đến những năm 2010
+
+**systemd (Hiện đại):**
+
+- Sử dụng unit file (các file `.service`) với cú pháp khai báo
+- Khởi động song song (các dịch vụ khởi động đồng thời khi dependencies được đáp ứng)
+- Thời gian boot nhanh
+- Quản lý dependency nâng cao, socket activation và nhiều tính năng khác
+- Trở thành tiêu chuẩn khoảng năm 2010-2015
+
+**Các Thành Phần Cốt Lõi:**
+
+- **systemd (PID 1)**: Tiến trình đầu tiên được kernel khởi động, chịu trách nhiệm khởi tạo hệ thống và quản lý tất cả các tiến trình khác
+- **systemd-journald**: Daemon ghi log thu thập và lưu trữ dữ liệu log
+- **systemctl**: Công cụ dòng lệnh để điều khiển các systemd service
+- **journalctl**: Công cụ dòng lệnh để truy vấn và xem journal logs
+
+**Tại Sao systemd Quan Trọng Với PAMSignal:**
+
+systemd cung cấp một cách tiếp cận hiện đại, thống nhất trong quản lý hệ thống, giải quyết những hạn chế của cách ghi log truyền thống:
+
+1. **Ghi Log Tập Trung**: Tất cả log hệ thống (kernel, dịch vụ, ứng dụng) được thu thập ở một nơi
+2. **Định Dạng Nhị Phân**: Log được lưu trữ ở định dạng nhị phân có index, có cấu trúc thay vì plain text
+3. **Metadata Phong Phú**: Mỗi log entry bao gồm metadata đầy đủ (PID, UID, tên dịch vụ, timestamp, v.v.)
+4. **API Event-Driven**: Các ứng dụng có thể đăng ký nhận sự kiện log theo thời gian thực qua `libsystemd`
+
+### 6.2 Kiến Trúc systemd-journald
+
+**Cách hoạt động:**
+
+```mermaid
+graph TD
+    kernel["Kernel<br/>(kmsg)"]
+    services["Services<br/>(stdout)"]
+    apps["Applications<br/>(sd_journal)"]
+    syslog["Syslog<br/>(legacy)"]
+
+    journald[("systemd-journald<br/>(central collector)")]
+    binary[("Binary journal<br/>/var/log/journal/<br/>indexed · sealed")]
+
+    journalctl["journalctl<br/>(query CLI)"]
+    libsystemd["libsystemd<br/>(event API)"]
+    rsyslog["rsyslog<br/>(forward)"]
+
+    kernel --> journald
+    services --> journald
+    apps --> journald
+    syslog --> journald
+
+    journald --> binary
+
+    binary --> journalctl
+    binary --> libsystemd
+    binary --> rsyslog
+
+    style kernel fill:#4a4e69,stroke:#22223b,color:#fff
+    style services fill:#577590,stroke:#1d3557,color:#fff
+    style apps fill:#577590,stroke:#1d3557,color:#fff
+    style syslog fill:#6c757d,stroke:#495057,color:#fff
+    style journald fill:#264653,stroke:#1d3557,color:#fff
+    style binary fill:#1d3557,stroke:#22223b,color:#fff
+    style journalctl fill:#e9c46a,stroke:#f4a261,color:#000
+    style libsystemd fill:#2d6a4f,stroke:#1b4332,color:#fff
+    style rsyslog fill:#6c757d,stroke:#495057,color:#fff
+```
+
+**Các Tính Năng Chính:**
+
+1. **Lưu Trữ Có Cấu Trúc**: Mỗi log entry là một bản ghi có cấu trúc với các cặp key-value
+2. **Indexing**: Truy vấn nhanh sử dụng các trường metadata (unit, priority, time range)
+3. **Chống Giả Mạo**: Forward Secure Sealing (FSS) tùy chọn ngăn chặn việc chỉnh sửa log
+4. **Rotation Tự Động**: Rotation theo kích thước và thời gian với khả năng lưu trữ có thể cấu hình
+5. **Hiệu Năng**: Được tối ưu hóa cho ghi log lưu lượng cao với overhead tối thiểu
+
+### 6.3 Ưu Điểm So Với Các File Log Truyền Thống
+
+| Tính năng | Truyền thống (`/var/log/auth.log`) | systemd-journald |
+|---------|--------------------------------|------------------|
+| **Định dạng** | Plain text, không có cấu trúc | Nhị phân, có cấu trúc với metadata |
+| **Phân tích cú pháp** | Regex/string parsing (dễ vỡ) | Truy cập trực tiếp theo trường (đáng tin cậy) |
+| **Hiệu năng** | Quét file tuần tự | Truy vấn có index |
+| **Thời gian thực** | File polling (độ trễ 500ms+) | API event-driven (độ trễ ~0ms) |
+| **Giả mạo** | Dễ chỉnh sửa/xóa | Niêm phong bằng cryptographic hashing |
+| **Metadata** | Hạn chế (timestamp, message) | Phong phú (PID, UID, dịch vụ, hostname, v.v.) |
+| **Rotation** | Cấu hình logrotate thủ công | Tự động với systemd |
+
+### 6.4 API Event-Driven của libsystemd
+
+Đối với PAMSignal, ưu điểm quan trọng nhất là **kiến trúc event-driven** được cung cấp bởi `libsystemd`:
+
+**Cách Tiếp Cận Truyền Thống (Polling):**
+```c
+while (1) {
+    read_log_file("/var/log/auth.log");
+    parse_new_lines();
+    sleep(500); // Waste CPU, miss events
+}
+```
+
+**Cách Tiếp Cận systemd (Event-Driven):**
+```c
+sd_journal *j;
+sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
+sd_journal_seek_tail(j);
+
+while (1) {
+    // Wait for new journal entries (blocking, no CPU waste)
+    sd_journal_wait(j, (uint64_t) -1);
+    
+    // Process new entries immediately
+    while (sd_journal_next(j) > 0) {
+        const void *data;
+        size_t length;
+        
+        // Direct field access, no parsing needed
+        sd_journal_get_data(j, "MESSAGE", &data, &length);
+        sd_journal_get_data(j, "_PID", &data, &length);
+        sd_journal_get_data(j, "_UID", &data, &length);
+    }
+}
+```
+
+**Các Hàm Chính:**
+
+- `sd_journal_open()`: Mở journal để đọc
+- `sd_journal_wait()`: Blocking cho đến khi có entry mới (event-driven)
+- `sd_journal_next()`: Di chuyển đến entry tiếp theo
+- `sd_journal_get_data()`: Lấy các trường cụ thể theo tên
+- `sd_journal_add_match()`: Lọc các entry theo tiêu chí (ví dụ: chỉ các sự kiện auth)
+
+**Lợi Ích cho PAMSignal:**
+
+1. ✅ **Zero polling overhead**: CPU chỉ sử dụng khi có sự kiện
+2. ✅ **Thông báo tức thì**: Độ trễ ~0ms từ sự kiện đến xử lý
+3. ✅ **Phân tích cú pháp đáng tin cậy**: Không có regex, truy cập trực tiếp theo trường
+4. ✅ **Phát hiện giả mạo**: Log được niêm phong ngăn kẻ tấn công xóa log
+5. ✅ **Tương thích đa distro**: Hoạt động trên tất cả các distro dựa trên systemd
+
+Kiến trúc này biến PAMSignal thành một giải pháp giám sát xác thực thực sự thời gian thực, hiệu quả và đáng tin cậy.

--- a/docs/vi/threat-model.md
+++ b/docs/vi/threat-model.md
@@ -1,0 +1,273 @@
+# Threat Model
+
+> 🌐 [English](../threat-model.md) · **Tiếng Việt**
+
+Tài liệu này mô tả những gì PAMSignal bảo vệ, những gì nó chủ động không bảo vệ, và các lựa chọn thiết kế tạo nên tư thế đó. Đây là tài liệu tham chiếu để đánh giá các đóng góp trong tương lai: một thay đổi củng cố biện pháp giảm thiểu trong phạm vi là chào đón; một thay đổi kéo công việc vào daemon từ một lĩnh vực ngoài phạm vi thì không, dù về mặt kỹ thuật có thể thực hiện được.
+
+Để báo cáo lỗ hổng bảo mật riêng tư, xem [`SECURITY.md`](../../SECURITY.md). Hai tài liệu bổ sung cho nhau — `SECURITY.md` hướng đến operator (cách báo cáo, phiên bản nào được hỗ trợ); tài liệu này hướng đến contributor (trách nhiệm của daemon là gì và không phải là gì).
+
+## Mục đích
+
+PAMSignal quan sát các sự kiện xác thực PAM trên một host duy nhất qua systemd journal và, khi các mẫu được cấu hình xảy ra (đăng nhập thất bại, ngưỡng brute-force), gửi cảnh báo qua HTTPS đến các kênh do operator lựa chọn. Nhiệm vụ của daemon là trở thành một **tín hiệu phát hiện đáng tin cậy** cho operator. Mọi biện pháp bảo vệ trong tài liệu này đều tồn tại để bảo tồn thuộc tính đó — rằng cảnh báo operator nhận được phản ánh chính xác những gì đã xảy ra trên host.
+
+## Phạm vi quan sát
+
+PAMSignal quan sát các sự kiện chạy qua PAM stack của host và vào journal của systemd. Đây là một nguồn tín hiệu *cụ thể*. Nó nắm bắt các kênh truy cập từ xa hàng ngày mà operator quan tâm — ssh, sftp, scp, rsync over ssh, sudo, su, login, xrdp + PAM, vsftpd / proftpd được cấu hình với PAM. Nó **không** quan sát mọi kênh qua đó một kết nối có thể đến host. Việc biết ranh giới một cách rõ ràng là một phần của threat model.
+
+### Các kênh PAMSignal quan sát
+
+| Kênh | Daemon nền | Những gì được ghi lại |
+|---|---|---|
+| Interactive SSH | `sshd` / `sshd-session` | LOGIN_SUCCESS, LOGIN_FAILED, SESSION_OPEN, SESSION_CLOSE |
+| SFTP | `sshd` (subsystem) | Cùng các mục auth + session như SSH |
+| SCP | `sshd` | Tương tự |
+| Rsync over SSH | `sshd` | Tương tự |
+| sudo / su | `pam_unix(sudo:auth)` / `pam_unix(su:auth)` | LOGIN_FAILED (với brute-force tracker keyed by `ruser`), SESSION_OPEN/CLOSE khi thành công |
+| TTY / console login | `login` | SESSION_OPEN/CLOSE |
+| xrdp với PAM | xrdp + `pam_unix` | SESSION_OPEN/CLOSE nếu được cấu hình dùng PAM |
+| vsftpd / proftpd với PAM | self + `pam_unix` | Nếu FTP daemon được cấu hình xác thực qua PAM |
+| systemd-logind sessions | `systemd-logind` | SESSION_OPEN/CLOSE khi mỗi session được tạo |
+
+### Các kênh PAMSignal KHÔNG quan sát
+
+Các kênh này xác thực qua các cơ chế mà journald không bao giờ thấy sự kiện PAM auth. Chúng là điểm mù thực sự trong bất kỳ lớp phát hiện dựa trên PAM nào, và chúng là các non-goal rõ ràng (mục ngoài phạm vi NS3 bao gồm journald bị xâm phạm; danh sách này mở rộng lý luận đó sang các nguồn tín hiệu *không phải* journald):
+
+| Kênh | Cơ chế xác thực | Audit trail của operator nằm ở |
+|---|---|---|
+| WireGuard / OpenVPN / IPsec VPN | xác thực peer mã hóa | Log network-layer (kernel netlink events, `wg show` polling, log riêng của OpenVPN) |
+| Tailscale SSH | Tailscale identity → mTLS | Tailscale admin console / `tailscale set --log` |
+| AWS SSM Session Manager | IAM → SSM agent | CloudTrail |
+| GCP Cloud IAP / OS Login | Google IAM | Cloud Audit Logs |
+| Azure Bastion | Azure RBAC | Azure Activity Log |
+| Teleport / Boundary / StrongDM | lớp identity riêng của chúng | Audit log của sản phẩm |
+| `kubectl exec` vào container | Kubernetes RBAC | k8s API server audit log |
+| IPMI / BMC / iDRAC / iLO | firmware BMC | Out-of-band management plane (riêng biệt, theo nhà cung cấp) |
+| Serial console | truy cập vật lý | Không có ở tầng OS — bảo mật vật lý |
+| NFS / SMB mounts | NFS/Kerberos / SMB | nfsd / smbd logs |
+| `rclone` với HTTP/S3/GCS backend | API tokens | Log truy cập của cloud provider |
+| Custom HTTP / REST / gRPC APIs | application-level | Audit log của ứng dụng |
+
+### Hàm ý cho operator
+
+Nếu PAMSignal là lớp alerting *duy nhất* trên một host, một kẻ tấn công tiếp cận host qua bất kỳ kênh bypass nào ở trên sẽ tạo ra **zero** sự kiện PAMSignal. Câu trả lời thực tế là **phát hiện theo lớp** — pamsignal cho các kênh PAM-stack (nơi traffic brute-force hàng ngày xuất hiện), cộng với một monitor riêng cho mỗi đường dẫn truy cập khác mà môi trường của operator lộ ra, tất cả đưa vào cùng SIEM qua pamsignal's ECS JSON webhook payload (hoặc tương đương). Các tài sản và kẻ tấn công trong threat model dưới đây được giới hạn trong các kênh PAM-stack; một operator triển khai pamsignal như một tín hiệu bảo mật nên xếp lớp tương ứng.
+
+## Tài sản
+
+Theo thứ tự ưu tiên:
+
+1. **Tính toàn vẹn và kịp thời của cảnh báo.** Nếu kẻ tấn công có thể chặn, trì hoãn, giả mạo hoặc làm ngập cảnh báo, giá trị của PAMSignal với operator sẽ sụp đổ. Đây là tài sản quan trọng nhất.
+2. **Thông tin xác thực cảnh báo.** Token bot Telegram, URL và bearer token Slack/Teams/Discord/custom-webhook, được lưu trong `/etc/pamsignal/pamsignal.conf` với quyền `0640 root:pamsignal`. Việc lộ chúng cho phép kẻ tấn công giả mạo cảnh báo (mạo danh PAMSignal với operator) và làm cạn kiệt giới hạn rate của kênh.
+3. **Phong bì đặc quyền của system user `pamsignal`.** Chỉ đọc journal; không có capability, không tạo namespace, không load kernel-module, không SUID transition, không writable executable memory. Một sự xâm phạm thoát khỏi phong bì này là một sự xâm phạm toàn bộ host.
+4. **Các mục journal có cấu trúc mà PAMSignal ghi** (`SYSLOG_IDENTIFIER=pamsignal`). Chúng cung cấp cho việc ingest SIEM downstream. Các mục phải phản ánh trạng thái quan sát thực tế, không phải nội dung do kẻ tấn công kiểm soát.
+
+Journal của host, `/etc/passwd`, trạng thái kernel, v.v. **không phải** tài sản của PAMSignal để bảo vệ — chúng thuộc về journald, kernel và tư thế hardening rộng hơn của operator.
+
+## Kẻ tấn công
+
+Threat model giả định các năng lực kẻ tấn công sau. Một thay đổi nằm trong phạm vi nếu nó củng cố biện pháp bảo vệ của chúng ta chống lại các kẻ tấn công được đặt tên; ngoài phạm vi nếu nó dựa vào các giả định ngoài danh sách này.
+
+### A. Kẻ tấn công từ xa bên ngoài (không có quyền truy cập host)
+
+Năng lực: gửi traffic mạng tùy ý, quan sát phản hồi, chạy máy quét tự động chống lại các dịch vụ lộ ra của host. Không thể chạy code trên host. Lớp kẻ tấn công phổ biến nhất — máy quét brute-force SSH, credential-stuffing tự động.
+
+Những gì chúng có thể làm mà PAMSignal quan tâm:
+- Tạo ra các mục journal sshd trông có vẻ xác thực (sự kiện failed-password thực) ở tốc độ cao.
+- Cố gắng làm tràn ngập brute-force tracker (table eviction, cooldown bypass, thao túng time-window bằng cách gửi sự kiện với timing được tạo thủ công).
+- DoS đường cảnh báo gián tiếp bằng cách tạo đủ sự kiện đáng cảnh báo để làm cạn kiệt giới hạn rate của kênh chat của operator.
+
+### B. Người dùng cục bộ không có đặc quyền (shell trên host, non-root, không trong group `pamsignal`)
+
+Năng lực: bất kỳ syscall nào mà người dùng non-root có thể thực hiện trên một host Linux không có sandbox. Cụ thể: `logger(1)`, ghi vào `/dev/log`, đọc `/proc/<any>/cmdline`, đọc các mục journal mà group `systemd-journal` có thể đọc (thường chỉ của người dùng của họ), kết nối đến các local socket được phép.
+
+Những gì chúng có thể làm mà PAMSignal quan tâm:
+- Inject các dòng auth giả mạo qua `logger(1)` — `logger -t sshd "Failed password for root from ..."` — hy vọng PAMSignal sẽ xử lý chúng như sự kiện sshd thực.
+- Kích hoạt các lần thất bại xác thực thực của chính họ (`sudo` với mật khẩu sai) để tạo cảnh báo.
+- Đọc `/proc/<pamsignal-pid>/cmdline` tìm kiếm thông tin xác thực trong các tham số khởi động.
+- Đọc `/proc/<pamsignal-pid>/environ` tìm kiếm thông tin xác thực bị rò rỉ qua môi trường.
+
+### C. Người dùng cục bộ *trong* group `pamsignal` (lựa chọn có chủ đích của operator)
+
+Năng lực: B + đọc `/etc/pamsignal/pamsignal.conf` (quyền `0640 root:pamsignal`). Đây là theo thiết kế — daemon cũng cần quyền đọc. Một operator thêm người dùng không phải system vào group `pamsignal` đang đưa ra quyết định tin tưởng có chủ đích và PAMSignal không giả vờ bảo vệ chống lại người dùng đó.
+
+### D. Daemon `pamsignal` bị xâm phạm (ví dụ: parser RCE)
+
+Năng lực: thực thi code tùy ý trong phong bì đặc quyền của daemon — người dùng `pamsignal`, không có cap, `SystemCallFilter` allowlist của systemd unit, `MemoryDenyWriteExecute=yes`, `ProtectSystem=strict`. Từ đây, xâm phạm toàn bộ host đòi hỏi một leo thang đặc quyền cục bộ khác (một kernel CVE riêng biệt, cấu hình sudo sai, một binary có thể ghi bởi pamsignal ở đâu đó trong PATH).
+
+Những gì chúng có thể làm mà PAMSignal quan tâm:
+- Đọc thông tin xác thực cảnh báo từ `/etc/pamsignal/pamsignal.conf`.
+- Giả mạo các cảnh báo gửi đi đến các kênh được cấu hình.
+- Chặn các cảnh báo thực bằng cách return sớm từ đường gửi cảnh báo.
+- Cố thoát sandbox qua các syscall còn lại được cho phép bởi `SystemCallFilter`.
+
+### E. Kẻ tấn công mạng trên đường cảnh báo
+
+Năng lực: drop, delay, replay, hoặc cố MITM yêu cầu HTTPS từ daemon đến alert provider được cấu hình.
+
+Những gì chúng có thể làm mà PAMSignal quan tâm:
+- Drop cảnh báo (operator không bao giờ thấy sự kiện).
+- MITM nếu TLS bị broken/downgraded/unverified.
+- Không thể giải mã hoặc giả mạo yêu cầu được bảo vệ TLS đến một webhook được cấu hình đúng.
+
+## Trong phạm vi: các cuộc tấn công mà daemon bảo vệ
+
+Mỗi mục nêu tên cuộc tấn công, lớp kẻ tấn công từ trên, biện pháp giảm thiểu và vị trí source. Một regression trong bất kỳ mục nào là một lỗi bảo mật và thuộc [`SECURITY.md`](../../SECURITY.md).
+
+### 1. Log injection qua `logger(1)` (B)
+
+**Cuộc tấn công.** Một người dùng không có đặc quyền cục bộ chạy `logger -t sshd "Failed password for root from 1.2.3.4 port 22 ssh2"` để giả mạo một mục journal trông như lỗi xác thực sshd thực. Không có filtering, PAMSignal sẽ cảnh báo và brute-force tracker sẽ đếm nó.
+
+**Biện pháp giảm thiểu.** `_EXE` allowlist trong `src/journal_watch.c:345-381`. Trường `_EXE` được ghi lại của mỗi mục journal (do journald tự đặt dựa trên binary thực sự được execve'd) phải resolve thành `sshd`, `sudo`, `su`, `login`, hoặc `systemd-logind` dưới một prefix hệ thống (`/usr/`, `/bin/`, `/sbin/`, `/lib/`, `/lib64/`, `/opt/`). Các mục không có `_EXE` (injection tổng hợp từ `/dev/log`) bị drop. `_EXE` của `logger` là `/usr/bin/logger` — không có trong allowlist, nên mục bị drop thầm lặng.
+
+### 2. Bypass brute-force tracker (A, B)
+
+**Cuộc tấn công.** Gửi các sự kiện failed-auth được tính thời gian cẩn thận để tăng bộ đếm per-key mà không bao giờ vượt ngưỡng; hoặc tạo đủ key kẻ tấn công riêng biệt để đẩy mục của target hợp lệ ra khỏi bảng.
+
+**Biện pháp giảm thiểu.**
+- `fail_window_sec` (`src/config.c:95`, mặc định 300s, phạm vi 1–86400) giới hạn time window để tổng hợp các lần thử. Logic sliding-window trong `src/journal_watch.c` reset count một khi `event->timestamp_usec - first_attempt_usec > window_usec`, nên kẻ tấn công không thể trải đều thất bại trên một window tùy ý dài để ở dưới ngưỡng.
+- Eviction chọn **cũ nhất theo `last_attempt_usec`**, không phải theo `first_attempt_usec` — một kẻ tấn công liên tục làm mới `last_attempt_usec` bằng các thất bại mới không thể đẩy entry của chính họ ra; chúng đẩy một entry khác, ưu tiên thấp hơn ra.
+- Per-key cooldown (`alert_cooldown_sec`, `src/journal_watch.c:223-232`) ngăn alert flooding từ một key đơn mà không mất bộ đếm bên dưới.
+
+### 3. Lộ thông tin xác thực cảnh báo qua process metadata (B, D)
+
+**Cuộc tấn công.** Đọc `/proc/<pamsignal-pid>/cmdline` hoặc `/proc/<pamsignal-curl-child-pid>/cmdline` để thu thập token bot Telegram, URL webhook, bearer token custom-webhook, hoặc đường dẫn trên đĩa của file cert / key mTLS client.
+
+**Biện pháp giảm thiểu.** Mỗi sender theo kênh đều đi qua file curl `-K` config được tạo bởi `memfd_create()` (`src/notify.c:101`) mang URL, `webhook_auth_header` tùy chọn (từ v0.4.0), và các đường dẫn `cert =` / `key =` / `cacert =` tùy chọn (từ v0.4.0). Memfd được pin ở `fd 9` qua `dup2` (xóa `O_CLOEXEC` trên đích); mọi descriptor kế thừa khác được đóng trong tiến trình con trước `execv`. argv của tiến trình con curl byte-identical cho mọi lần gửi cảnh báo — `curl -s -S --max-time 10 --proto =https --proto-redir =https -H "Content-Type: application/json" -K /dev/fd/9 -d <body>` — bất kể kênh nào hay chế độ xác thực nào đang được dùng. Một người dùng không có đặc quyền đọc `/proc/*/cmdline` không thể biết liệu có token, client cert, hay cả hai được cấu hình, chứ chưa nói đến việc thu thập các giá trị đó. argv của daemon cha là `pamsignal --foreground` cộng với `--config <path>` tùy chọn — không có thông tin xác thực nào ở đó.
+
+### 4. Hijack alert dispatch qua `PATH` / `LD_PRELOAD` (D)
+
+**Cuộc tấn công.** Một daemon pamsignal bị xâm phạm thao túng môi trường của tiến trình con curl để chuyển hướng nó qua một binary hoặc library do kẻ tấn công kiểm soát.
+
+**Biện pháp giảm thiểu.** Tiến trình con curl thực hiện `clearenv()` (`src/notify.c:184`), rồi `setenv("PATH", "/usr/bin:/bin", 1)`, rồi `execv("/usr/bin/curl", …)` với đường dẫn tuyệt đối nên `PATH` không được tham khảo. `LD_PRELOAD` bị drop bởi `clearenv()`. systemd unit cũng đặt `Environment=PATH=/usr/bin:/bin` (`pamsignal.service.in:30`) để phòng thủ theo chiều sâu khi daemon được khởi động ngoài unit.
+
+### 5. TLS downgrade / cleartext webhook (E)
+
+**Cuộc tấn công.** Một `webhook_url = http://...` được cấu hình sai hoặc chuyển hướng sang `http://` sẽ lộ nội dung cảnh báo và thông tin xác thực cho người quan sát mạng thụ động.
+
+**Biện pháp giảm thiểu.** URL validator của PAMSignal từ chối các URL không phải `https://` tại thời điểm load config (`src/config.c`); lời gọi curl truyền `--proto =https --proto-redir =https` (`src/notify.c`) nên ngay cả kẻ tấn công quản lý inject một redirect `Location: http://...` cũng không thể bắt curl theo nó.
+
+### 6. Alert payload injection (A → D)
+
+**Cuộc tấn công.** Một username, hostname, hoặc trường PAM-message chứa các ký tự có ý nghĩa JSON hoặc control byte, dẫn đến payload bị dị dạng hoặc thoát ra khỏi JSON quoting.
+
+**Biện pháp giảm thiểu.**
+- `sanitize_string()` (`src/utils.c:13`) thay thế tất cả control character (0x00–0x1F + 0x7F) bằng `?` trên mọi username và target_username đã trích xuất, ngay sau khi parsing.
+- `is_valid_ip()` (`src/utils.c:21`) yêu cầu `inet_pton` chấp nhận source IP; thất bại xóa trường.
+- `json_escape()` (`src/notify.c:27`) RFC 8259 escape `"`, `\`, tất cả byte 0x00–0x1F, cộng với các short escape chuẩn cho `\b\f\n\r\t`. Ngay cả khi `sanitize_string` bị regression, JSON quoting vẫn giữ.
+- Tất cả extraction được bounded: username vào buffer 64-byte với marker truncation `+` (`src/utils.c:63-77`), hostname bounded bởi `event.hostname[256]`, `sscanf` dùng width specifier ở mọi nơi.
+
+### 7. Thoát sandbox từ daemon bị xâm phạm (D)
+
+**Cuộc tấn công.** Parser-level RCE trong code C đạt được thực thi tùy ý ở mức người dùng `pamsignal`, rồi cố leo thang lên root.
+
+**Biện pháp giảm thiểu (chiều sâu, không hoàn hảo):**
+- `User=pamsignal Group=pamsignal` (không có đặc quyền để bắt đầu).
+- `CapabilityBoundingSet=` trống (`pamsignal.service.in:53`).
+- `NoNewPrivileges=yes` (`pamsignal.service.in:38`) — các binary SUID `setuid` trở thành no-op.
+- `MemoryDenyWriteExecute=yes` (`pamsignal.service.in:46`) — shellcode injection đòi hỏi một kernel bug riêng biệt.
+- `ProtectSystem=strict`, `ProtectHome=yes`, `PrivateTmp=yes`, `PrivateDevices=yes`, `ProtectKernelTunables=yes`, `ProtectKernelModules=yes`, `ProtectKernelLogs=yes`, `ProtectControlGroups=yes`.
+- `RestrictNamespaces=yes`, `RestrictRealtime=yes`, `RestrictSUIDSGID=yes`, `LockPersonality=yes`.
+- `SystemCallFilter=@system-service ~@privileged @resources` — bpf, mount, kexec, finit_module, v.v. đều bị từ chối.
+- `RLIMIT_NPROC` giới hạn ở 64 trong `src/main.c` nên fork-bomb trong đường cảnh báo không thể làm cạn kiệt process slot.
+- `prctl(PR_SET_NO_NEW_PRIVS, 1)` được đặt sớm trong `src/main.c` ngay cả bên ngoài unit.
+
+Điểm systemd-analyze security (CI-gated ở ≤30 trên thang 0–100 nội bộ; hiện tại 22) là guard regression cho các directive này.
+
+### 8. Lỗi memory-safety trong C parser (A → D)
+
+**Cuộc tấn công.** Nội dung mục journal được tạo thủ công kích hoạt buffer overflow / use-after-free / integer overflow trong `ps_parse_message` hoặc xử lý string downstream.
+
+**Biện pháp giảm thiểu.**
+- Compiler hardening: `-fstack-protector-strong`, `-D_FORTIFY_SOURCE=3`, `-fcf-protection=full` (Intel CET), `-fstack-clash-protection`, full RELRO, PIE, `-z noexecstack`, `-z separate-code` (`meson.build`).
+- Harness libFuzzer trong `tests/fuzz_parse_message.c` bao phủ điểm vào chính của parser. Chạy với `CC=clang meson setup -Dfuzz=enabled build-fuzz && build-fuzz/fuzz_parse_message tests/fuzz/parse_message_corpus -max_total_time=60`.
+- 98 test CMocka trên bốn suite, bao gồm parser edge case (username bị truncate, control character, IP-validation failure, thông báo PAM multi-`user=`, IPv6 literal).
+- clang-tidy + clang-analyzer trong CI với `WarningsAsErrors` trên family checker `clang-analyzer-security.*`.
+
+### 9. Alert-volume DoS từ một source IP đơn (A)
+
+**Cuộc tấn công.** Một máy quét chạy mãi mãi chống lại một IP, tạo ra hàng nghìn cảnh báo brute-force làm ngập kênh chat của operator.
+
+**Biện pháp giảm thiểu.** Per-source-IP cooldown trong `src/journal_watch.c:223-232`. Sau khi một cảnh báo threshold-breach được kích hoạt, cùng IP đó không thể kích hoạt cảnh báo khác trong `alert_cooldown_sec` giây (mặc định 60s), nhưng bộ đếm bên dưới và các mục journal vẫn tiếp tục. Điều này nén các cảnh báo tấn công liên tục thành một ping chat mỗi cooldown period mà không mất khả năng quan sát.
+
+## Ngoài phạm vi: các cuộc tấn công PAMSignal không bảo vệ
+
+Đây là các non-goal có chủ đích. Một thay đổi cố gắng mở rộng daemon để bảo vệ chống lại bất kỳ mục nào trong số chúng sẽ bị từ chối trừ khi toàn bộ threat model đang được mở rộng.
+
+### NS1. Kẻ tấn công đã có root trên host được giám sát
+
+Một khi kẻ tấn công có root, họ có thể `systemctl stop pamsignal`, thay thế `/usr/bin/pamsignal` bằng một no-op, chỉnh sửa `/etc/pamsignal/pamsignal.conf` để trỏ cảnh báo đến webhook của họ, hoặc `kill -STOP` daemon để đóng băng nó. Không có usermode daemon nào bảo vệ chống lại root, và pamsignal không giả vờ như vậy.
+
+### NS2. Kẻ tấn công trong group `pamsignal`
+
+Group này là ranh giới truy cập đọc có chủ đích cho file cấu hình. Một operator thêm người dùng không phải system vào đó đang tự nguyện mở rộng tin tưởng cho người dùng đó. PAMSignal không bảo vệ chống lại các thành viên của group mang thông tin xác thực của chính nó.
+
+### NS3. journald bị xâm phạm
+
+PAMSignal tin tưởng các trường `_EXE`, `_PID`, `_UID`, và `_HOSTNAME` của journald. journald đặt các trường này từ metadata process do kernel cung cấp tại thời điểm ghi; PAMSignal không thể xác minh độc lập chúng. Nếu journald bị xâm phạm (hoặc, thực tế hơn, nếu kernel's `/proc/<pid>/exe` lookup bị hỏng bởi một kernel CVE), `_EXE` allowlist không có tác dụng.
+
+### NS4. `libsystemd` hoặc `curl` bị xâm phạm
+
+PAMSignal link với `libsystemd` và exec `/usr/bin/curl`. Một trojan trong một trong hai là vấn đề host-compromise mà package manager và chuỗi cung ứng package có chữ ký nên bắt ở upstream của PAMSignal.
+
+### NS5. Alert provider bị xâm phạm
+
+Bằng cách cấu hình `telegram_bot_token` / `slack_webhook_url` / v.v., operator mở rộng tin tưởng đến các dịch vụ đó. Nếu Telegram bị xâm phạm, cảnh báo của operator sẽ bị kẻ tấn công nhìn thấy. Biện pháp giảm thiểu là lựa chọn của operator — dùng kênh custom-webhook trỏ đến cơ sở hạ tầng do operator kiểm soát.
+
+### NS6. Độ bền gửi cảnh báo khi mạng gặp sự cố
+
+Cảnh báo PAMSignal là fire-and-forget: một tiến trình con curl được fork+exec'd, tiến trình cha không chờ hoàn thành hay retry khi thất bại. Nếu mạng bị sập hoặc alert provider không đến được, cảnh báo sẽ **bị mất**. Đây là một đánh đổi có chủ đích — giao hàng bền vững đòi hỏi queueing, queueing đòi hỏi on-disk state, mở rộng bề mặt tấn công (tấn công state-corruption, DoS disk-full, v.v.). Operator cần giao hàng cảnh báo bền vững nên gửi đến custom webhook receiver họ kiểm soát, với logic queueing và retry riêng của họ.
+
+### NS7. Tương quan đa host
+
+Mỗi instance PAMSignal độc lập. Không có aggregation trung tâm, không có bảng brute-force chia sẻ giữa các host. Một kẻ tấn công tấn công 50 host với 4 lần thử mỗi host sẽ không kích hoạt bất kỳ ngưỡng nào, ngay cả khi mẫu tích lũy rõ ràng là một cuộc tấn công. Operator cần tương quan đa host sẽ pipe đầu ra JSON-webhook vào một SIEM thực hiện tương quan đúng cách.
+
+### NS8. Alert payload được ký HMAC
+
+Kể từ v0.4.0, kênh custom-webhook có thể xác thực đến receiver của nó qua shared-secret HTTP header (`webhook_auth_header`, ví dụ: `Authorization: Bearer …`, API key, hoặc Splunk/Datadog token) hoặc mTLS (`webhook_client_cert` + `webhook_client_key`, `webhook_ca_bundle` tùy chọn), theo cách cộng thêm. Cả hai đều là xác thực *transport-layer*: receiver biết kết nối đến từ người nắm giữ secret / cert. **Những gì pamsignal vẫn không làm là HMAC-sign *payload* — không có body signature, không có replay-protection nonce, không có per-event MAC.** Một receiver đã chấp nhận một request không thể chứng minh body không bị replay bởi một client đã xác thực trước đó, và một token bị rò rỉ có thể replay cho đến khi được rotate. HMAC payload signing có chủ đích ngoài phạm vi: nó sẽ đòi hỏi link libcrypto vào daemon (hoặc tự làm SHA-256), và threat model mà nó bảo vệ chống lại (giao hàng bên thứ ba qua intermediary không tin cậy, theo kiểu GitHub/Stripe webhook delivery) không khớp với deployment shape của pamsignal (operator → lớp ingest SIEM của chính operator qua TLS). Operator với adversary model đó nên pre-share state qua mTLS và để receiver thực hiện payload-level deduplication trên `(host, @timestamp, event.action)`. Các kênh chat (Telegram, Slack, Teams, WhatsApp, Discord) xác thực bằng scheme token-in-URL hoặc bearer riêng của mỗi provider; pamsignal không thêm lớp auth thứ hai lên trên.
+
+### NS9. Bảo vệ chống admin misconfiguration
+
+Nếu operator đặt `pamsignal.conf` ở quyền `0644` (world-readable) và lưu thông tin xác thực trong đó, PAMSignal sẽ khởi động (sau khi cảnh báo tại thời điểm load config) nhưng thông tin xác thực bị lộ. Cải thiện mặc định là chào đón như feature request; coi đây là lỗi bảo mật thì không phù hợp.
+
+### NS10. Network-side DoS nhắm vào tài nguyên của chính daemon
+
+Kẻ tấn công có thể tạo ra hàng triệu sự kiện journal hợp lệ mỗi giây có thể bão hòa CPU của PAMSignal. Daemon không tự giới hạn rate đầu vào của mình — nó xử lý bất cứ thứ gì journald đưa cho nó. Theo điểm systemd-analyze, daemon không thể fork-bomb hệ thống (`RLIMIT_NPROC=64`) hoặc làm cạn kiệt bộ nhớ vượt quá cấu trúc dữ liệu bounded của nó (`max_tracked_ips`), nhưng nó có thể bị chậm lại. Câu trả lời chuẩn cho input-side DoS trên một host đơn là firewalling, auto-banning kiểu fail2ban, hoặc journald-side rate limits (`RateLimitIntervalSec=`, `RateLimitBurst=`).
+
+## Ranh giới tin tưởng
+
+Ranh giới tin tưởng là nơi trong hệ thống mà dữ liệu không tin cậy hoặc bị ảnh hưởng bởi kẻ tấn công vượt qua vào vùng được xử lý như đã được định dạng đúng. Mỗi ranh giới có một validator được chỉ định; lỗi trong validator là lớp lỗi ưu tiên cao nhất.
+
+| Ranh giới | Phía không tin cậy | Validator | Source |
+|---|---|---|---|
+| Journal entry → parser | Trường `MESSAGE` được journald ghi lại | `ps_parse_message` + `_EXE` allowlist | `src/utils.c`, `src/journal_watch.c:345-381` |
+| Conf file → daemon config | Nội dung file (do root kiểm soát nhưng trên đĩa) | `ps_config_load` + kiểm tra permission/ownership | `src/config.c:249-300` |
+| Event → JSON webhook payload | `event->username`, `event->source_ip`, `event->hostname` | `sanitize_string` + `json_escape` | `src/utils.c:13`, `src/notify.c:27` |
+| Daemon → curl child | URL webhook, bearer token, đường dẫn cert/key/CA mTLS, body | memfd-backed `--config` (URL + `header =` tùy chọn + `cert/key/cacert =` tùy chọn), fixed argv, `--proto =https`, absolute-path `execv` | `src/notify.c:101-209` |
+| Config → curl `-K` parser | Giá trị chuỗi từ `pamsignal.conf` | `is_https_url` (URL), `is_http_header` (auth header), `validate_tls_path` (cert/key/CA paths từ chối `"`, `\`, control char, follow-symlinks, world-readable key) | `src/config.c:140-330` |
+
+## Hạn chế thiết kế (đánh đổi có chủ đích)
+
+Đây là những lựa chọn dự án đã thực hiện *cho* sự đơn giản và bề mặt tấn công nhỏ hơn, với nhận thức đầy đủ về chi phí:
+
+- **Brute-force tracker trong bộ nhớ**, bị xóa khi restart (được bảo tồn qua SIGHUP). Chi phí: restart daemon reset bộ đếm per-IP, tạm thời mở cửa cho kẻ tấn công retry. Được giảm thiểu bởi `fail_window_sec` ngắn (mặc định 300s — khớp với thời gian restart điển hình).
+- **Không load PAM module.** PAMSignal không chạy bên trong PAM stack; nó quan sát các đầu ra của stack. Chi phí: nó không thể can thiệp để *chặn* một lần thử xác thực, chỉ cảnh báo về nó. Lợi ích: không có privileged code nào trong PAM authentication path.
+- **Không có persistent state trên đĩa.** Daemon không ghi gì vào `/var/lib/`. Chi phí: không có lịch sử brute-force qua các lần restart, không có state offline-analysis. Lợi ích: không có gì để corrupt, không có gì để disk-fill, không có gì để rò rỉ.
+- **Phạm vi một host.** Không có clustering, không có shared state, không có central server. Chi phí: aggregation là mối quan tâm SIEM ngoài băng. Lợi ích: daemon đơn tiến trình, không có network listening port, không có xác thực giữa các instance.
+- **Fire-and-forget alerts.** Đã thảo luận trong NS6 ở trên.
+
+Đây là những ranh giới mà người đề xuất tính năng nên dừng lại và hỏi liệu tính năng có đáng với chi phí — và câu trả lời thường là "không, hãy dùng custom-webhook escape hatch."
+
+## Hướng dẫn cho operator
+
+Một cài đặt PAMSignal chỉ an toàn như cấu hình xung quanh nó. Threat model giả định operator tuân theo các hướng dẫn này:
+
+1. **Không thêm người dùng không tin tưởng vào group `pamsignal`.** Làm vậy mở rộng quyền đọc file cấu hình (và do đó quyền truy cập thông tin xác thực cảnh báo) cho những người dùng đó. `postinst` của package không thêm ai; thành viên duy nhất theo mặc định là daemon.
+2. **Giữ `/etc/pamsignal/pamsignal.conf` ở `0640 root:pamsignal`.** Package đặt điều này khi cài đặt lần đầu. PAMSignal cảnh báo khi khởi động nếu quyền lỏng hơn; nó không từ chối khởi động, phòng trường hợp operator cố tình chạy với quyền nghiêm ngặt hơn.
+3. **Với triển khai high-assurance, hãy gửi cảnh báo đến custom webhook bạn kiểm soát.** Các nhà cung cấp chat bên thứ ba (Telegram, Slack, Teams, Discord, WhatsApp) thấy metadata cảnh báo của bạn. Một webhook trên cơ sở hạ tầng bạn kiểm soát cho bạn storage bền vững, aggregation đa host, và kiểm soát đầy đủ về retention. Xác thực kết nối đến receiver bằng `webhook_auth_header` (Bearer / API key / Splunk HEC / Datadog), hoặc — nếu môi trường của bạn chạy PKI — `webhook_client_cert` + `webhook_client_key` cho mTLS. Hai cách kết hợp theo kiểu cộng thêm. Xem [Configuration → Custom webhook authentication](configuration.md#xác-thực-custom-webhook).
+4. **Đặt `webhook_client_key` ở quyền `0640 root:pamsignal`** (hoặc `0600 pamsignal:pamsignal` nếu bạn chạy daemon bằng người dùng đó). PAMSignal từ chối khởi động nếu key có thể đọc bởi group hoặc world. Cert và CA bundle không có ràng buộc tương tự — chúng là tài liệu công khai.
+5. **Rotate thông tin xác thực cảnh báo định kỳ.** PAMSignal không tự rotate thông tin xác thực; rotation là trách nhiệm của operator. Với token shared-secret (token bot Telegram, `webhook_auth_header`, v.v.), cập nhật `pamsignal.conf` và `systemctl reload pamsignal`. Với `webhook_client_cert` / `webhook_client_key`, thay thế file tại chỗ — cert manager (cert-manager / certbot / `systemd-creds`) xử lý atomic rotation; lần gửi cảnh báo tiếp theo tự động lấy file mới. SIGHUP không cần thiết để rotate cert/key vì các đường dẫn trong config không thay đổi.
+6. **Không chạy PAMSignal bằng `root`.** Nó từ chối dù sao, nhưng kỳ vọng cơ bản là daemon ở lại người dùng `pamsignal` do package tạo. Override unit tùy chỉnh thay đổi `User=` làm mất hiệu lực threat model.
+7. **Để phòng thủ theo chiều sâu trên đường cảnh báo, kết hợp PAMSignal với một instance fail2ban (hoặc tương đương)** tiêu thụ cùng các mục journal để thêm firewall rule. PAMSignal quan sát; fail2ban hành động. Hai cái bổ sung nhau, không dư thừa; xem `../../examples/fail2ban/` trong repo này để xem integration mẫu.
+
+## Báo cáo vấn đề
+
+Các lỗ hổng nên được báo cáo riêng tư theo kênh và timeline trong [`SECURITY.md`](../../SECURITY.md). Phân chia in-scope/out-of-scope trong `SECURITY.md` khớp với tài liệu này; tài liệu này cung cấp lý luận kỹ thuật đằng sau phân chia đó.

--- a/examples/bruno-collection/README.md
+++ b/examples/bruno-collection/README.md
@@ -1,5 +1,7 @@
 # PAMSignal Webhook Bruno Collection
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/bruno-collection.md)
+
 Ready-to-use [Bruno](https://www.usebruno.com/) requests for testing any PAMSignal webhook receiver — the [Node.js example](../nodejs-webhook/), the [Python example](../python-webhook/), or any other implementation of the same `POST /webhook/pamsignal` contract.
 
 Tested with **Bruno ≥ 3.3.0**.

--- a/examples/fail2ban/README.md
+++ b/examples/fail2ban/README.md
@@ -1,5 +1,7 @@
 # Fail2ban Integration Guide
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/fail2ban.md)
+
 This guide walks you through setting up [Fail2ban](https://github.com/fail2ban/fail2ban) so that whenever PAMSignal detects a brute-force attack, the attacker's IP is automatically blocked at the firewall. Examples cover **Ubuntu 22.04+ / Debian 12+** and **CentOS Stream 9 / AlmaLinux 9 / Rocky Linux 9** (same commands work on Fedora 40+ too).
 
 If you've never used Fail2ban before — that's fine. The guide explains every concept as it introduces it.

--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -1,5 +1,7 @@
 # PAMSignal — Grafana integration
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/grafana.md)
+
 Fleet-wide SSH/sudo/su/login monitoring for PAMSignal, in Grafana.
 
 ![PAMSignal dashboard](../../assets/grafana-dashboard.png)

--- a/examples/nodejs-webhook/README.md
+++ b/examples/nodejs-webhook/README.md
@@ -1,5 +1,7 @@
 # PAMSignal Node.js Webhook Receiver
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/nodejs-webhook.md)
+
 This is a ready-to-use example of a Custom Webhook receiver built with **TypeScript**, Node.js, and Express. It receives structured ECS JSON alerts from PAMSignal and processes them.
 
 This example incorporates Express best practices, including:

--- a/examples/python-webhook/README.md
+++ b/examples/python-webhook/README.md
@@ -1,5 +1,7 @@
 # PAMSignal Python Webhook Receiver
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/python-webhook.md)
+
 This is a ready-to-use example of a Custom Webhook receiver built with **Python** and **Flask**. It receives structured ECS JSON alerts from PAMSignal and processes them. It is the Python counterpart to the `examples/nodejs-webhook/` example and exposes the same endpoint contract, env vars, and mTLS behavior.
 
 This example incorporates:

--- a/examples/shared-certs/README.md
+++ b/examples/shared-certs/README.md
@@ -1,5 +1,7 @@
 # Shared mTLS Demo Certs
 
+> 🌐 **English** · [Tiếng Việt](../../docs/vi/examples/shared-certs.md)
+
 A single, self-contained CA + server cert + client cert used by all three example projects to demonstrate the PAMSignal webhook's mTLS path. **Local/demo only — never use these certs in production.**
 
 ## What's here


### PR DESCRIPTION
Adds full Vietnamese documentation alongside the existing English docs so readers can follow in either language, and codifies the bilingual rule in CLAUDE.md so the two never drift.

## What changed

- **20 new Vietnamese files** under `docs/vi/`, mirroring the English tree:
  - `README.md`, `SECURITY.md`, `CONTRIBUTING.md`
  - the 8 `docs/` guides (configuration, alerts, deployment, distros, architecture, threat-model, grafana-integration, development)
  - the 3 `docs/notes/`
  - the 6 example guides (`examples/<name>/README.md` → `docs/vi/examples/<name>.md`)
- **Language switcher** blockquote after the H1 of every doc, both directions (EN ⇄ VI).
- **CLAUDE.md** documents the convention: English is the source of truth, Vietnamese mirrors under `docs/vi/`, edit both in the same change.

## Convention

| Aspect | Rule |
|---|---|
| Layout | `docs/<x>.md` → `docs/vi/<x>.md`; root docs → `docs/vi/<x>.md`; examples → `docs/vi/examples/<x>.md` |
| Switcher | `> 🌐 **English** · [Tiếng Việt](…)` on EN; `> 🌐 [English](…) · **Tiếng Việt**` on VI |
| Translate | prose, headings, table prose |
| Keep verbatim | technical terms, config keys, CLI flags, paths, code blocks, commands, URLs, Mermaid/ASCII diagrams |
| Structure | 1:1 with the English source (same headings, sections, anchors) |
| Links in VI | translated-doc links → VI counterpart; non-translated (source, CHANGELOG, LICENSE, assets, .claude) → real file with depth recomputed; anchor links → Vietnamese heading slug |

## Verification

- 170 relative file links checked — all resolve except two **pre-existing** English-side broken links, mirrored faithfully (the deleted-locally-but-present-on-main `.claude/skills/owasp-review/SKILL.md`, and an already-broken `phase-1-meson_guide.md` reference in `project-initialization.md`).
- 27 cross-document anchor links checked — all resolve to the correct Vietnamese heading slugs (fixed 8 that initially pointed at English anchors).

## Notes for review

- Some H1 titles were left in English (e.g. `# Configuration` rather than `# Cấu hình`) — functionally fine; localizing them is a judgment call for a native reader.
- The pre-existing `phase-1-meson_guide.md` broken link now exists in both EN and VI; left untouched to keep this PR scoped to translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)