### PR TITLE
chore: debian packaging hygiene (watch, upstream metadata, Standards-Version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+**Debian packaging hygiene.** Added `debian/watch` (uscan tracks upstream releases from GitHub tags) and `debian/upstream/metadata` (DEP-12 bug-database / repository links), and bumped `Standards-Version` to 4.7.0. These make the existing `.deb` lintian-cleaner and "adoption-ready" so a Debian/Ubuntu maintainer — or a future archive submission — can pick it up with minimal extra work. The self-hosted apt repo stays the primary channel; official Debian-archive inclusion is deferred until the project has more traction.
+
 **Grafana integration** ([#25](https://github.com/anhtuank7c/pamsignal/issues/25)). New `examples/grafana/` directory ships everything an operator with a Linux fleet needs to surface PAMSignal events in a single Grafana dashboard:
 
 - `alloy.river` — production [Grafana Alloy](https://grafana.com/docs/alloy/latest/) config. Reads systemd journald filtered to `SYSLOG_IDENTIFIER=pamsignal`, promotes four low-cardinality fields (`app`, `host`, `service`, `event_action`) to Loki labels, and keeps everything else (`SOURCE_IP`, `USER_NAME`, ...) in the JSON line body for query-time parsing. Total streams stay at ~30 × fleet_size — safe to thousands of hosts.

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 12~),
                pkg-config,
                libsystemd-dev,
                libcmocka-dev
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Homepage: https://github.com/anhtuank7c/pamsignal
 Vcs-Git: https://github.com/anhtuank7c/pamsignal.git
 Vcs-Browser: https://github.com/anhtuank7c/pamsignal

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/anhtuank7c/pamsignal/issues
+Bug-Submit: https://github.com/anhtuank7c/pamsignal/issues/new
+Repository: https://github.com/anhtuank7c/pamsignal.git
+Repository-Browse: https://github.com/anhtuank7c/pamsignal

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,10 @@
+version=4
+
+# Track upstream releases from GitHub tags (v0.6.1, v0.7.0, ...).
+# git mode is used because it is robust against GitHub's periodic changes to
+# the HTML tags page; uscan produces a tarball named pamsignal-<version>.tar.gz
+# with the leading "v" stripped from the tag.
+opts="mode=git, gitmode=shallow, pgpmode=none, \
+filenamemangle=s%.*%pamsignal-$1.tar.gz%" \
+  https://github.com/anhtuank7c/pamsignal.git \
+  refs/tags/v@ANY_VERSION@ debian uupdate


### PR DESCRIPTION
## Summary

A small **adoption-readiness** polish for the existing `debian/` package — no build changes, no change to the self-hosted apt-repo workflow. Context: we decided to **keep apt as the channel** and **defer official Debian-archive inclusion** until the project has more traction (the Fail2ban model — distros package tools once they earn the demand), but to do the cheap hygiene now so that path is trivial later and a downstream maintainer could adopt it easily.

## What changed
- **`debian/watch`** (new) — lets `uscan` track upstream releases from GitHub tags (`v0.6.1`, …). Uses **git mode** (robust against GitHub's periodic tags-page HTML changes) and renames to `pamsignal-<version>.tar.gz`.
- **`debian/upstream/metadata`** (new) — DEP-12 `Bug-Database` / `Bug-Submit` / `Repository` / `Repository-Browse`.
- **`debian/control`** — `Standards-Version` `4.6.2` → `4.7.0`.
- **`CHANGELOG.md`** — Unreleased note.

## Review notes (the package was already in good shape)
Things I checked and **deliberately did not change**:
- **`debian/copyright`** is already DEP-5 / machine-readable ✓
- **`Rules-Requires-Root: no`**, hardened `rules` (`hardening=+all`), clean idempotent maintainer scripts (`set -e`, `#DEBHELPER#`, system user via `adduser --system`) ✓
- **`debhelper` compat *file* (`13`)** instead of the `debhelper-compat (= 13)` build-dep — kept, because it's an intentional choice to also build on Ubuntu 20.04/Focal (debhelper 12.10). A pure Debian-archive submission would switch to the build-dep, but that would drop Focal.
- **`Depends: systemd`** — kept; legitimate since the daemon requires journald.

## ⚠️ Needs a Linux verification pass
This was a **static** review (authored on macOS — can't run `lintian`/`dpkg-buildpackage` here). Before relying on it, on a Debian/Ubuntu box:
```bash
dpkg-buildpackage -us -uc -b
lintian -I --pedantic ../pamsignal_*.deb ../pamsignal_*.dsc
uscan --report --verbose      # confirm debian/watch finds v0.6.1
```
`Standards-Version` was bumped without walking the full policy upgrading-checklist — worth a skim, though `4.6.2 → 4.7.0` is minor and the package already follows the modern conventions it asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
