### PR TITLE
chore(release): 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.6.2 — 2026-06-03
+
+Patch release — **no daemon code changes** (the binary is byte-identical to 0.6.1). Ships the Grafana fleet-dashboard integration, a from-scratch documentation & onboarding overhaul (EN + VI), and Debian packaging hygiene. Details below.
 
 **Debian packaging hygiene.** Added `debian/watch` (uscan tracks upstream releases from GitHub tags) and `debian/upstream/metadata` (DEP-12 bug-database / repository links), and bumped `Standards-Version` to 4.7.0. These make the existing `.deb` lintian-cleaner and "adoption-ready" so a Debian/Ubuntu maintainer — or a future archive submission — can pick it up with minimal extra work. The self-hosted apt repo stays the primary channel; official Debian-archive inclusion is deferred until the project has more traction.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+pamsignal (0.6.2-1) unstable; urgency=medium
+
+  * No daemon code changes; documentation, integration, and packaging only.
+  * Grafana integration under examples/grafana/ (Alloy config, 12-panel
+    fleet dashboard, 4 Grafana-native alert rules, docker-compose try-it
+    stack, verify.sh) plus the docs/grafana-integration.md design doc.
+  * Documentation overhaul: restructured README and three new guides
+    (Secure SSH & fleet management, Grafana from zero, Use Cases &
+    Integrations), each mirrored in Vietnamese under docs/vi/.
+  * Packaging: add debian/watch (uscan tracks upstream GitHub tags) and
+    debian/upstream/metadata (DEP-12); bump Standards-Version to 4.7.0.
+
+ -- Tuan Nguyen <anhtuank7c@hotmail.com>  Wed, 03 Jun 2026 06:49:52 +0000
+
 pamsignal (0.6.1-1) unstable; urgency=medium
 
   * Feature: --help / -h flag. Prints a usage summary covering every

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('pamsignal', 'c',
-  version: '0.6.1',
+  version: '0.6.2',
   default_options: [
     'c_std=gnu17',
     'warning_level=2',

--- a/pamsignal.spec
+++ b/pamsignal.spec
@@ -1,5 +1,5 @@
 Name:           pamsignal
-Version:        0.6.1
+Version:        0.6.2
 Release:        1%{?dist}
 Summary:        Real-time PAM login monitor with multi-channel alerts
 


### PR DESCRIPTION
## Release 0.6.2

Rolls the accumulated `## Unreleased` work into a tagged patch release. **No daemon code changes** — the binary is byte-identical to 0.6.1, so this is a *patch* under your convention (minor = new daemon capability/milestone or breaking change; patch = fixes, docs, integrations, packaging — consistent with 0.6.1 and 0.4.1).

### What ships in 0.6.2
- **Grafana integration** — `examples/grafana/` (Alloy config, 12-panel fleet dashboard, 4 alert rules, docker-compose try-it stack, `verify.sh`) + the design doc.
- **Docs/onboarding overhaul (EN + VI)** — restructured README + three new guides (Secure SSH & fleet, Grafana from zero, Use Cases).
- **Debian packaging hygiene** — `debian/watch`, `debian/upstream/metadata`, `Standards-Version` 4.7.0.

### Version lockstep (so `verify-versions` passes)
All four sources now agree on `0.6.2` — the release-packages gate checks tag == meson == `debian/changelog` upstream == spec:
| Source | New value |
|---|---|
| `meson.build` | `0.6.2` |
| `debian/changelog` | `0.6.2-1` |
| `pamsignal.spec` | `Version: 0.6.2` |
| `CHANGELOG.md` | `## 0.6.2 — 2026-06-03` |

### Heads-up
`pamsignal.spec`'s `%changelog` is **stale** (top entry `0.4.0`; 0.5.0/0.6.0/0.6.1 were never backfilled). I left it as-is — the gate only reads the `Version:` field, and adding a lone 0.6.2 entry over that gap would be misleading. Backfilling the spec changelog is a separate cleanup if you want it.

### ▶️ How the release actually fires (after this merges)
`release-packages.yml` triggers on **`release: published`**, not on a bare tag. So the sequence is:
1. Merge this PR to `main`.
2. **Create a GitHub Release for tag `v0.6.2`** (targeting `main`) → CI runs `verify-versions`, builds + tests the .deb (noble + focal) and .rpm (fedora + el9), GPG-signs them, attaches them to the release, and publishes the signed apt + dnf repos to gh-pages.

I'll create that release once you've merged + are happy with the notes (it's the public-publish trigger, so I'll wait for your go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
