### PR TITLE
Fixed several bugs related to parsing CLI arguments, added comments, …

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -84,9 +84,9 @@ static int parse_notification_mask(const char *val, unsigned int *out) {
         return -1;
 
     unsigned int mask = 0;
-    int matched_any = 0;
     char *p = buf;
-    while (1) {
+
+    do {
         char *comma = strchr(p, ',');
         if (comma)
             *comma = '\0';
@@ -94,6 +94,7 @@ static int parse_notification_mask(const char *val, unsigned int *out) {
         char *t = trim(p);
         if (*t == '\0')
             return -1;
+
         for (char *q = t; *q; q++)
             *q = (char)tolower((unsigned char)*q);
 
@@ -102,19 +103,17 @@ static int parse_notification_mask(const char *val, unsigned int *out) {
             if (strcmp(t, tokens[i].name) == 0) {
                 mask |= tokens[i].flag;
                 found = 1;
-                matched_any = 1;
                 break;
             }
         }
         if (!found)
             return -1;
 
-        if (!comma)
-            break;
-        p = comma + 1;
-    }
-    if (!matched_any)
-        return -1;
+        p = comma? comma + 1 : NULL;
+    } while ( p != NULL);
+
+    // mask != 0 is guaranteed here: the loop ran at least once,
+    // every iteration either found a token or returned -1.
     *out = mask;
     return 0;
 }
@@ -187,6 +186,8 @@ static int has_only_chars(const char *s, int (*pred)(int)) {
     return 1;
 }
 
+// isdigit() is a macro; it cannot retrieve an address.
+// The `is_digit_int()` function exists to contain the address to it.
 static int is_digit_int(int c) {
     return isdigit(c);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <syslog.h>
 #include <systemd/sd-daemon.h>
 #include <systemd/sd-journal.h>
@@ -49,6 +50,20 @@ static void print_help(void) {
         PS_DEFAULT_CONFIG_PATH, PS_DEFAULT_CONFIG_PATH);
 }
 
+// Check that the path to the file actually exists.
+static int path_exists_and_readable(const char *path) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        fprintf(stderr, "pamsignal: '%s': %s\n", path, strerror(errno));
+        return 1;
+    }
+    if (access(path, R_OK) != 0) {
+        fprintf(stderr, "pamsignal: '%s': %s\n", path, strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
 static void parse_args(int argc, char *argv[], int *foreground,
                        const char **config_path) {
     *foreground = 0;
@@ -74,6 +89,10 @@ static void parse_args(int argc, char *argv[], int *foreground,
         } else if ((strcmp(argv[i], "--config") == 0 ||
                     strcmp(argv[i], "-c") == 0) &&
                    i + 1 < argc) {
+            // Check path
+            if(path_exists_and_readable(argv[i+1]) != 0) {
+                exit(0);
+            }
             *config_path = argv[++i];
         }
     }
@@ -102,9 +121,10 @@ static int has_journal_access(void) {
         return 1;
 
     // Supplementary groups
-    enum { PS_GROUPS_BUF_LEN = 256 };
+#define PS_GROUPS_BUF_LEN 256
     gid_t groups[PS_GROUPS_BUF_LEN];
     int ngroups = getgroups(PS_GROUPS_BUF_LEN, groups);
+#undef PS_GROUPS_BUF_LEN
     if (ngroups < 0)
         return 0;
 


### PR DESCRIPTION
- Instead of using the classic enum {}, switch to #define.
- Replace while(1)/break with do-while(p != NULL) to make the loop's exit condition explicit and remove the dead matched_any guard.
- Fixed a bug where users passed empty values ỏ invalid path(may be other flags or something) ​​to the parameters for -c and --config, and added a feature to check for existing paths before proceeding.